### PR TITLE
Proposal Address Validation

### DIFF
--- a/mooringlicensing/components/proposals/api.py
+++ b/mooringlicensing/components/proposals/api.py
@@ -108,7 +108,7 @@ from mooringlicensing.components.main.decorators import (
         query_debugger
         )
 from mooringlicensing.components.users.serializers import ProposalApplicantSerializer
-from mooringlicensing.helpers import is_authorised_to_modify, is_customer, is_internal
+from mooringlicensing.helpers import is_authorised_to_modify, is_customer, is_internal, is_applicant_address_set
 from rest_framework_datatables.pagination import DatatablesPageNumberPagination
 from rest_framework_datatables.filters import DatatablesFilterBackend
 from rest_framework_datatables.renderers import DatatablesRenderer
@@ -1513,6 +1513,9 @@ class ProposalViewSet(viewsets.ModelViewSet):
             is_authorised_to_modify(request, instance)
             
             save_proponent_data(instance, request, self)
+
+            is_applicant_address_set(instance)
+
             return Response()
 
     @detail_route(methods=['GET',], detail=True)

--- a/mooringlicensing/helpers.py
+++ b/mooringlicensing/helpers.py
@@ -110,3 +110,24 @@ def is_authorised_to_modify(request, instance):
 
     # if not authorised:
     #     raise serializers.ValidationError('You are not authorised to modify this application.')
+
+def is_applicant_address_set(instance):
+
+    applicant = instance.proposal_applicant
+
+    #residential address
+    if not applicant.residential_line1 or \
+        not applicant.residential_locality or \
+        not applicant.residential_state or \
+        not applicant.residential_country or \
+        not applicant.residential_postcode:
+        raise serializers.ValidationError('Residential Address details not provided')
+
+    #postal same as residential OR postal address
+    if not applicant.postal_same_as_residential and \
+        (not applicant.postal_line1 or \
+        not applicant.postal_locality or \
+        not applicant.postal_state or \
+        not applicant.postal_country or \
+        not applicant.postal_postcode):
+        raise serializers.ValidationError('Postal Address details not provided')


### PR DESCRIPTION
A proposal could be submitted without any address details - both residential and postal.

If a postal address is not provided, the sticker company will have nowhere to send a printed sticker.

This PR adds address validation. Proposal applications must now include:

- A residential address line 1, town/suburb, state, country, and postcode
- A postal address line 1, town/suburb, state, country, and postcode OR the same as residential address tick box must be ticked

If those details are not provided, the application will remain in the draft stage.