### PR TITLE
Vessel form adjustments

### DIFF
--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/vessels.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/vessels.vue
@@ -707,7 +707,7 @@ export default {
                                 error = e;
                                 console.error(e);
                             } finally {
-                                if (error){
+                                if (error.status == '400'){
                                     //empty the search
                                     var searchValue = "";
                                     var err = "The selected vessel is already listed with RIA under another owner";

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/vessels.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/vessels.vue
@@ -154,7 +154,7 @@
         </FormSection>
         <FormSection label="Vessel Details" Index="vessel_details">
             <div class="row form-group">
-                <label for="" class="col-sm-3 control-label">Vessel length *</label>
+                <label for="" class="col-sm-3 control-label">Vessel length (m) *</label>
                 <div class="col-sm-2">
                     <input :readonly="readonly" type="number" min="1" class="form-control" id="vessel_length" placeholder=""
                         v-model="vessel.vessel_details.vessel_length" required="" @change="emitVesselLength" />
@@ -168,7 +168,7 @@
                 </div>
             </div>
             <div class="row form-group">
-                <label for="" class="col-sm-3 control-label">Draft *</label>
+                <label for="" class="col-sm-3 control-label">Draft (m) *</label>
                 <div class="col-sm-2">
                     <input :readonly="readonly" type="number" min="1" class="form-control" id="draft" placeholder=""
                         v-model="vessel.vessel_details.vessel_draft" required="" />

--- a/mooringlicensing/frontend/mooringlicensing/src/components/external/dcv/dcv_admission.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/external/dcv/dcv_admission.vue
@@ -301,10 +301,32 @@ export default {
             return re.test(email)
         },
         lookupDcvVessel: async function(id) {
-            const res = await this.$http.get(api_endpoints.lookupDcvVessel(id));
-            const vesselData = res.body;
-            if (vesselData && vesselData.rego_no) {
-                this.dcv_admission.dcv_vessel = Object.assign({}, vesselData);
+            var error = null;
+            try {
+                const res = await this.$http.get(api_endpoints.lookupDcvVessel(id));
+            } catch(e) {
+                error = e;
+                
+            } finally {
+                if (error.status == '400'){
+                    //empty the search
+                    var searchValue = "";
+                    var err = "The selected vessel is already listed with RIA under another owner";
+                    swal({
+                        title: 'Selection Error',
+                        text: err,
+                        type: "error",
+                    })
+                    
+                    var option = new Option(searchValue, searchValue, true, true);
+                    $(this.$refs.dcv_vessel_rego_nos).append(option).trigger('change');
+                    
+                } else {
+                    const vesselData = res.body;
+                    if (vesselData && vesselData.rego_no) {
+                        this.dcv_admission.dcv_vessel = Object.assign({}, vesselData);
+                    }
+                }
             }
         },
         validateRegoNo: function(data) {

--- a/mooringlicensing/frontend/mooringlicensing/src/components/external/dcv/dcv_permit.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/external/dcv/dcv_permit.vue
@@ -127,12 +127,32 @@ export default {
     methods: {
         lookupDcvVessel: async function(id) {
             console.log('in lookupDcvVessel')
+            var error = null;
+            try {
             const res = await this.$http.get(api_endpoints.lookupDcvVessel(id));
-            const vesselData = res.body;
-            console.log('existing dcv_vessel: ')
-            console.log(vesselData);
-            if (vesselData && vesselData.rego_no) {
-                this.dcv_permit.dcv_vessel = Object.assign({}, vesselData);
+            } catch(e) {
+                error = e;
+            } finally {
+                if (error.status == '400'){
+                    //empty the search
+                    var searchValue = "";
+                    var err = "The selected vessel is already listed with RIA under another owner";
+                    swal({
+                        title: 'Selection Error',
+                        text: err,
+                        type: "error",
+                    })
+                    
+                    var option = new Option(searchValue, searchValue, true, true);
+                    $(this.$refs.dcv_vessel_rego_nos).append(option).trigger('change');                    
+                } else {
+                    const vesselData = res.body;
+                    console.log('existing dcv_vessel: ')
+                    console.log(vesselData);
+                    if (vesselData && vesselData.rego_no) {
+                        this.dcv_permit.dcv_vessel = Object.assign({}, vesselData);
+                    }
+                }
             }
         },
         validateRegoNo: function(data) {


### PR DESCRIPTION
On all applications forms where vessel registration can be searched, if a user selects a vessel registration that is not new and that they do not own they will be notified and then the search value will be removed.

Before, the vessel registration would be selectable and remain displayed as though the selection were valid, but the actual underlying value would not be set - this could lead to some confusion when the user receives an error informing them that no vessel has been set. 

Another problem is that if a legitimate vessel registration were set and then replaced with an invalid one - it would appear that the invalid registration would be submitted when the actual value would be that of the initially entered registration. Meaning a user could submit a registration value that they did not intend to.

The change will remove confusion by clearing the vessel registration field while informing the user that the registration is not valid.

Alongside this change was adding (m) notation to vessel length and draft form fields to convey they the measurements should be given in metres.