### PR TITLE
Remaining work for System User + internal user application editing

### DIFF
--- a/mooringlicensing/components/approvals/api.py
+++ b/mooringlicensing/components/approvals/api.py
@@ -25,6 +25,7 @@ from ledger_api_client.settings_base import TIME_ZONE
 from datetime import datetime
 from collections import OrderedDict
 from ledger_api_client.managed_models import SystemUser
+from ledger_api_client.utils import get_or_create
 
 from django.core.cache import cache
 from mooringlicensing import forms
@@ -34,8 +35,7 @@ from mooringlicensing.components.payments_ml.api import logger
 from mooringlicensing.components.payments_ml.models import FeePeriod, FeeSeason, FeeConstructor
 from mooringlicensing.components.payments_ml.serializers import DcvPermitSerializer, DcvAdmissionSerializer, \
     DcvAdmissionArrivalSerializer, NumberOfPeopleSerializer
-from mooringlicensing.components.proposals.models import Proposal, MooringLicenceApplication, ProposalType, Mooring, \
-    ProposalApplicant  #, ApplicationType
+from mooringlicensing.components.proposals.models import Proposal, MooringLicenceApplication, ProposalType, Mooring, ProposalApplicant
 from mooringlicensing.components.approvals.models import (
     Approval,
     DcvPermit, DcvOrganisation, DcvVessel, DcvAdmission, AdmissionType, AgeGroup,
@@ -814,7 +814,7 @@ class DcvAdmissionViewSet(viewsets.ModelViewSet):
                             if this_user:
                                 new_user = this_user.first()
                             else:
-                                new_user = EmailUser.objects.create(email=email_address, first_name=skipper) #TODO review this - is this allowed?
+                                new_user = get_or_create('email_address')
                             submitter = new_user
                         else:
                             raise forms.ValidationError('Please fill the skipper field')
@@ -1255,15 +1255,15 @@ class StickerFilterBackend(DatatablesFilterBackend):
         try:
             super_queryset = super(StickerFilterBackend, self).filter_queryset(request, queryset, view)
             if search_text:
-                email_user_ids = list(EmailUser.objects.annotate(full_name=Concat('first_name',Value(" "),'last_name',output_field=CharField()))
+                system_user_ids = list(SystemUser.objects.annotate(full_name=Concat('legal_first_name',Value(" "),'legal_last_name',output_field=CharField()))
                 .filter(
-                    Q(first_name__icontains=search_text) | Q(last_name__icontains=search_text) | Q(email__icontains=search_text) | Q(full_name__icontains=search_text)
-                ).values_list("id", flat=True))
+                    Q(legal_first_name__icontains=search_text) | Q(legal_last_name__icontains=search_text) | Q(email__icontains=search_text) | Q(full_name__icontains=search_text)
+                ).values_list("ledger_id", flat=True))
                 proposal_applicant_proposals = list(ProposalApplicant.objects.annotate(full_name=Concat('first_name',Value(" "),'last_name',output_field=CharField()))
                 .filter(
                     Q(first_name__icontains=search_text) | Q(last_name__icontains=search_text) | Q(email__icontains=search_text) | Q(full_name__icontains=search_text)
                 ).values_list("proposal_id", flat=True))
-                q_set = queryset.filter(Q(approval__current_proposal__id__in=proposal_applicant_proposals)|Q(approval__submitter__in=email_user_ids))
+                q_set = queryset.filter(Q(approval__current_proposal__id__in=proposal_applicant_proposals)|Q(approval__submitter__in=system_user_ids))
                 queryset = super_queryset.union(q_set)
         except Exception as e:
             print(e)

--- a/mooringlicensing/components/approvals/api.py
+++ b/mooringlicensing/components/approvals/api.py
@@ -362,19 +362,19 @@ class ApprovalFilterBackend(DatatablesFilterBackend):
 
             # Custom search
             search_text= request.data.get('search[value]')  # This has a search term.
-            #TODO: fix search
             if search_text:
                 # User can search by a fullname, too
-                email_user_ids = list(EmailUser.objects.annotate(full_name=Concat('first_name',Value(" "),'last_name',output_field=CharField()))
+                system_user_ids = list(SystemUser.objects.annotate(full_name=Concat('legal_first_name',Value(" "),'legal_last_name',output_field=CharField()))
                 .filter(
-                    Q(first_name__icontains=search_text) | Q(last_name__icontains=search_text) | Q(email__icontains=search_text) | Q(full_name__icontains=search_text)
-                ).values_list("id", flat=True))
+                    Q(legal_first_name__icontains=search_text) | Q(legal_last_name__icontains=search_text) | Q(email__icontains=search_text) | Q(full_name__icontains=search_text)
+                ).values_list("ledger_id", flat=True))
+
                 proposal_applicant_proposals = list(ProposalApplicant.objects.annotate(full_name=Concat('first_name',Value(" "),'last_name',output_field=CharField()))
                 .filter(
                     Q(first_name__icontains=search_text) | Q(last_name__icontains=search_text) | Q(email__icontains=search_text) | Q(full_name__icontains=search_text)
                 ).values_list("proposal_id", flat=True))
 
-                q_set = queryset.filter(Q(current_proposal__id__in=proposal_applicant_proposals)|Q(current_proposal__submitter__in=email_user_ids))
+                q_set = queryset.filter(Q(current_proposal__id__in=proposal_applicant_proposals)|Q(current_proposal__submitter__in=system_user_ids))
 
                 queryset = super_queryset.union(q_set)
         except Exception as e:
@@ -1254,8 +1254,6 @@ class StickerFilterBackend(DatatablesFilterBackend):
         #2) other filters DO override the custom search
         try:
             super_queryset = super(StickerFilterBackend, self).filter_queryset(request, queryset, view)
-
-            #TODO: fix search
             if search_text:
                 email_user_ids = list(EmailUser.objects.annotate(full_name=Concat('first_name',Value(" "),'last_name',output_field=CharField()))
                 .filter(

--- a/mooringlicensing/components/approvals/api.py
+++ b/mooringlicensing/components/approvals/api.py
@@ -19,7 +19,6 @@ from rest_framework.decorators import action as list_route
 from rest_framework.decorators import renderer_classes
 from rest_framework.response import Response
 from rest_framework.renderers import JSONRenderer
-# from ledger.accounts.models import EmailUser
 from ledger_api_client.ledger_models import EmailUserRO as EmailUser
 # from ledger.settings_base import TIME_ZONE
 from ledger_api_client.settings_base import TIME_ZONE
@@ -363,9 +362,8 @@ class ApprovalFilterBackend(DatatablesFilterBackend):
 
             # Custom search
             search_text= request.data.get('search[value]')  # This has a search term.
+            #TODO: fix search
             if search_text:
-            # if re.search(r'\s{1,}', search_term):
-                # email_user_ids = EmailUser.objects.filter(Q(first_name__icontains=search_term) | Q(last_name__icontains=search_term) | Q(email__icontains=search_term)).values_list('id', flat=True)
                 # User can search by a fullname, too
                 email_user_ids = list(EmailUser.objects.annotate(full_name=Concat('first_name',Value(" "),'last_name',output_field=CharField()))
                 .filter(
@@ -816,7 +814,7 @@ class DcvAdmissionViewSet(viewsets.ModelViewSet):
                             if this_user:
                                 new_user = this_user.first()
                             else:
-                                new_user = EmailUser.objects.create(email=email_address, first_name=skipper)
+                                new_user = EmailUser.objects.create(email=email_address, first_name=skipper) #TODO review this - is this allowed?
                             submitter = new_user
                         else:
                             raise forms.ValidationError('Please fill the skipper field')
@@ -1257,6 +1255,7 @@ class StickerFilterBackend(DatatablesFilterBackend):
         try:
             super_queryset = super(StickerFilterBackend, self).filter_queryset(request, queryset, view)
 
+            #TODO: fix search
             if search_text:
                 email_user_ids = list(EmailUser.objects.annotate(full_name=Concat('first_name',Value(" "),'last_name',output_field=CharField()))
                 .filter(

--- a/mooringlicensing/components/approvals/email.py
+++ b/mooringlicensing/components/approvals/email.py
@@ -76,46 +76,6 @@ class AuthorisedUserMooringRemovedNotificationEmail(TemplateEmailBase):
         self.subject = '{} - {} expired.'.format(settings.RIA_NAME, approval.child_obj.description)
 
 
-# def send_auth_user_no_moorings_notification(approval):
-#     email = AuthorisedUserNoMooringsNotificationEmail(approval)
-#     proposal = approval.current_proposal
-#
-#     url=settings.SITE_URL if settings.SITE_URL else ''
-#     url += reverse('external')
-#
-#     if "-internal" in url:
-#         # remove '-internal'. This email is for external submitters
-#         url = ''.join(url.split('-internal'))
-#
-#     context = {
-#         'recipient': approval.submitter_obj,
-#         'public_url': get_public_url(),
-#         'approval': approval,
-#         'proposal': proposal,
-#         'url': make_http_https(url),
-#     }
-#     all_ccs = []
-#     if proposal.org_applicant and proposal.org_applicant.email:
-#         cc_list = proposal.org_applicant.email
-#         if cc_list:
-#             all_ccs = [cc_list]
-#     msg = email.send(proposal.submitter_obj.email, cc=all_ccs, context=context)
-#     if msg:
-#         sender = settings.DEFAULT_FROM_EMAIL
-#         try:
-#             sender_user = EmailUser.objects.get(email__icontains=sender)
-#         except:
-#             EmailUser.objects.create(email=sender, password='')
-#             sender_user = EmailUser.objects.get(email__icontains=sender)
-#
-#         _log_approval_email(msg, approval, sender=sender_user)
-#         #_log_org_email(msg, approval.applicant, proposal.submitter, sender=sender_user)
-#         if approval.org_applicant:
-#             _log_org_email(msg, approval.org_applicant, proposal.submitter_obj, sender=sender_user)
-#         else:
-#             _log_user_email(msg, approval.submitter_obj, proposal.submitter_obj, sender=sender_user)
-
-
 def send_auth_user_mooring_removed_notification(approval, mooring_licence):
     email = AuthorisedUserMooringRemovedNotificationEmail(approval)
     proposal = approval.current_proposal
@@ -146,8 +106,7 @@ def send_auth_user_mooring_removed_notification(approval, mooring_licence):
         try:
             sender_user = EmailUser.objects.get(email__icontains=sender)
         except:
-            EmailUser.objects.create(email=sender, password='') #TODO: is this allowed?
-            sender_user = EmailUser.objects.get(email__icontains=sender)
+            sender_user = None
 
         _log_approval_email(msg, approval, sender=sender_user)
         #_log_org_email(msg, approval.applicant, proposal.submitter, sender=sender_user)
@@ -192,8 +151,7 @@ def send_approval_expire_email_notification(approval):
         try:
             sender_user = EmailUser.objects.get(email__icontains=sender)
         except:
-            EmailUser.objects.create(email=sender, password='') #TODO is this allowed?
-            sender_user = EmailUser.objects.get(email__icontains=sender)
+            sender_user = None
 
         _log_approval_email(msg, approval, sender=sender_user)
         #_log_org_email(msg, approval.applicant, proposal.submitter, sender=sender_user)
@@ -227,8 +185,7 @@ def send_approval_cancelled_due_to_no_vessels_nominated_mail(approval, request=N
     try:
         sender_user = EmailUser.objects.get(email__icontains=sender)
     except:
-        EmailUser.objects.create(email=sender, password='') #TODO: is this allowed?
-        sender_user = EmailUser.objects.get(email__icontains=sender)
+        sender_user = None
 
 
     #approver_group = ProposalApproverGroup.objects.all().first()
@@ -272,8 +229,7 @@ def send_vessel_nomination_reminder_mail(approval, request=None):
     try:
         sender_user = EmailUser.objects.get(email__icontains=sender)
     except:
-        EmailUser.objects.create(email=sender, password='') #TODO: is this allowed?
-        sender_user = EmailUser.objects.get(email__icontains=sender)
+        sender_user = None
 
     to_address = approval.submitter_obj.email
     all_ccs = []
@@ -589,8 +545,7 @@ def send_approval_cancel_email_notification(approval):
     try:
         sender_user = EmailUser.objects.get(email__icontains=sender)
     except:
-        EmailUser.objects.create(email=sender, password='') #TODO: is this allowed?
-        sender_user = EmailUser.objects.get(email__icontains=sender)
+        sender_user = None
     all_ccs = []
     if proposal.org_applicant and proposal.org_applicant.email:
         cc_list = proposal.org_applicant.email
@@ -640,8 +595,7 @@ def send_approval_suspend_email_notification(approval, request=None):
     try:
         sender_user = EmailUser.objects.get(email__icontains=sender)
     except:
-        EmailUser.objects.create(email=sender, password='') #TODO: is this allowed?
-        sender_user = EmailUser.objects.get(email__icontains=sender)
+        sender_user = None
     all_ccs = []
     if proposal.org_applicant and proposal.org_applicant.email:
         cc_list = proposal.org_applicant.email
@@ -693,8 +647,7 @@ def send_approval_surrender_email_notification(approval, request=None, already_s
     try:
         sender_user = EmailUser.objects.get(email__icontains=sender)
     except:
-        EmailUser.objects.create(email=sender, password='') #TODO: is this allowed?
-        sender_user = EmailUser.objects.get(email__icontains=sender)
+        sender_user = None
     all_ccs = []
     if proposal.org_applicant and proposal.org_applicant.email:
         cc_list = proposal.org_applicant.email

--- a/mooringlicensing/components/approvals/email.py
+++ b/mooringlicensing/components/approvals/email.py
@@ -15,7 +15,6 @@ from datetime import timedelta
 # from ledger.payments.pdf import create_invoice_pdf_bytes
 from mooringlicensing import settings
 from mooringlicensing.components.emails.emails import TemplateEmailBase, _extract_email_headers
-# from ledger.accounts.models import EmailUser
 from ledger_api_client.ledger_models import EmailUserRO as EmailUser, EmailUserRO
 from mooringlicensing.components.emails.utils import get_user_as_email_user, get_public_url, make_http_https
 from mooringlicensing.components.users.models import EmailUserLogEntry
@@ -147,7 +146,7 @@ def send_auth_user_mooring_removed_notification(approval, mooring_licence):
         try:
             sender_user = EmailUser.objects.get(email__icontains=sender)
         except:
-            EmailUser.objects.create(email=sender, password='')
+            EmailUser.objects.create(email=sender, password='') #TODO: is this allowed?
             sender_user = EmailUser.objects.get(email__icontains=sender)
 
         _log_approval_email(msg, approval, sender=sender_user)
@@ -193,7 +192,7 @@ def send_approval_expire_email_notification(approval):
         try:
             sender_user = EmailUser.objects.get(email__icontains=sender)
         except:
-            EmailUser.objects.create(email=sender, password='')
+            EmailUser.objects.create(email=sender, password='') #TODO is this allowed?
             sender_user = EmailUser.objects.get(email__icontains=sender)
 
         _log_approval_email(msg, approval, sender=sender_user)
@@ -228,7 +227,7 @@ def send_approval_cancelled_due_to_no_vessels_nominated_mail(approval, request=N
     try:
         sender_user = EmailUser.objects.get(email__icontains=sender)
     except:
-        EmailUser.objects.create(email=sender, password='')
+        EmailUser.objects.create(email=sender, password='') #TODO: is this allowed?
         sender_user = EmailUser.objects.get(email__icontains=sender)
 
 
@@ -273,7 +272,7 @@ def send_vessel_nomination_reminder_mail(approval, request=None):
     try:
         sender_user = EmailUser.objects.get(email__icontains=sender)
     except:
-        EmailUser.objects.create(email=sender, password='')
+        EmailUser.objects.create(email=sender, password='') #TODO: is this allowed?
         sender_user = EmailUser.objects.get(email__icontains=sender)
 
     to_address = approval.submitter_obj.email
@@ -590,7 +589,7 @@ def send_approval_cancel_email_notification(approval):
     try:
         sender_user = EmailUser.objects.get(email__icontains=sender)
     except:
-        EmailUser.objects.create(email=sender, password='')
+        EmailUser.objects.create(email=sender, password='') #TODO: is this allowed?
         sender_user = EmailUser.objects.get(email__icontains=sender)
     all_ccs = []
     if proposal.org_applicant and proposal.org_applicant.email:
@@ -641,7 +640,7 @@ def send_approval_suspend_email_notification(approval, request=None):
     try:
         sender_user = EmailUser.objects.get(email__icontains=sender)
     except:
-        EmailUser.objects.create(email=sender, password='')
+        EmailUser.objects.create(email=sender, password='') #TODO: is this allowed?
         sender_user = EmailUser.objects.get(email__icontains=sender)
     all_ccs = []
     if proposal.org_applicant and proposal.org_applicant.email:
@@ -694,7 +693,7 @@ def send_approval_surrender_email_notification(approval, request=None, already_s
     try:
         sender_user = EmailUser.objects.get(email__icontains=sender)
     except:
-        EmailUser.objects.create(email=sender, password='')
+        EmailUser.objects.create(email=sender, password='') #TODO: is this allowed?
         sender_user = EmailUser.objects.get(email__icontains=sender)
     all_ccs = []
     if proposal.org_applicant and proposal.org_applicant.email:

--- a/mooringlicensing/components/approvals/models.py
+++ b/mooringlicensing/components/approvals/models.py
@@ -907,7 +907,7 @@ class Approval(RevisionedMixin):
         else:
             return ApprovalUserAction.log_action(self, action)
 
-    def expire_approval(self, user):
+    def expire_approval(self, user=None):
         with transaction.atomic():
             try:
                 today = timezone.localtime(timezone.now()).date()

--- a/mooringlicensing/components/approvals/models.py
+++ b/mooringlicensing/components/approvals/models.py
@@ -23,9 +23,8 @@ from django.db.models import Q
 from mooringlicensing.ledger_api_utils import retrieve_email_userro, get_invoice_payment_status
 # from ledger.settings_base import TIME_ZONE
 from mooringlicensing.settings import PROPOSAL_TYPE_SWAP_MOORINGS, TIME_ZONE, GROUP_DCV_PERMIT_ADMIN, PRIVATE_MEDIA_STORAGE_LOCATION, PRIVATE_MEDIA_BASE_URL
-# from ledger.accounts.models import EmailUser, RevisionedMixin
 # from ledger.payments.invoice.models import Invoice
-from ledger_api_client.ledger_models import EmailUserRO as EmailUser, Invoice, EmailUserRO
+from ledger_api_client.ledger_models import Invoice, EmailUserRO
 from mooringlicensing.components.approvals.pdf import create_dcv_permit_document, create_dcv_admission_document, \
     create_approval_doc, create_renewal_doc
 from mooringlicensing.components.emails.utils import get_public_url
@@ -329,10 +328,8 @@ class Approval(RevisionedMixin):
     expiry_date = models.DateField(blank=True, null=True)
     surrender_details = JSONField(blank=True,null=True)
     suspension_details = JSONField(blank=True,null=True)
-    # submitter = models.ForeignKey(EmailUser, on_delete=models.CASCADE, blank=True, null=True, related_name='mooringlicensing_approvals')
     submitter = models.IntegerField(blank=True, null=True)
     org_applicant = models.ForeignKey(Organisation, on_delete=models.CASCADE, blank=True, null=True, related_name='org_approvals')
-    # proxy_applicant = models.ForeignKey(EmailUser, on_delete=models.CASCADE, blank=True, null=True, related_name='proxy_approvals')
     proxy_applicant = models.IntegerField(blank=True, null=True)
     extracted_fields = JSONField(blank=True, null=True)
     cancellation_details = models.TextField(blank=True)
@@ -781,6 +778,7 @@ class Approval(RevisionedMixin):
             logger.warning(f'Current proposal of the approval: [{self}] not found.')
             return None
 
+    #TODO review - when would this isinstance check be required? (same for is_approver)
     def is_assessor(self, user):
         if isinstance(user, EmailUserRO):
             user = user.id
@@ -2464,7 +2462,6 @@ class ApprovalUserAction(UserAction):
             what=str(action)
         )
 
-    # who = models.ForeignKey(EmailUser, null=True, blank=True, on_delete=models.CASCADE)
     who = models.IntegerField(null=True, blank=True)
     when = models.DateTimeField(null=False, blank=False, auto_now_add=True)
     what = models.TextField(blank=False)
@@ -3359,7 +3356,6 @@ class StickerActionDetail(models.Model):
     date_of_lost_sticker = models.DateField(blank=True, null=True)
     date_of_returned_sticker = models.DateField(blank=True, null=True)
     action = models.CharField(max_length=50, null=True, blank=True)
-    # user = models.ForeignKey(EmailUser, null=True, blank=True, on_delete=models.SET_NULL)
     user = models.IntegerField(null=True, blank=True)
     sticker_action_fee = models.ForeignKey(StickerActionFee, null=True, blank=True, related_name='sticker_action_details', on_delete=models.SET_NULL)
     waive_the_fee = models.BooleanField(default=False)

--- a/mooringlicensing/components/approvals/serializers.py
+++ b/mooringlicensing/components/approvals/serializers.py
@@ -31,7 +31,7 @@ from mooringlicensing.components.organisations.models import (
 from mooringlicensing.components.main.serializers import CommunicationLogEntrySerializer, InvoiceSerializer
 from mooringlicensing.components.proposals.serializers import InternalProposalSerializer, \
     MooringSimpleSerializer, \
-    ProposalApplicantSerializer  # EmailUserAppViewSerializer
+    ProposalApplicantSerializer
 from mooringlicensing.components.users.serializers import UserSerializer
 from rest_framework import serializers
 from django.core.exceptions import ObjectDoesNotExist

--- a/mooringlicensing/components/compliances/api.py
+++ b/mooringlicensing/components/compliances/api.py
@@ -28,7 +28,6 @@ from rest_framework.renderers import JSONRenderer
 # from datetime import datetime, timedelta
 # from collections import OrderedDict
 from django.core.cache import cache
-# from ledger.accounts.models import EmailUser, Address
 from ledger_api_client.ledger_models import EmailUserRO as EmailUser
 from mooringlicensing.components.main.decorators import basic_exception_handler
 
@@ -296,6 +295,7 @@ class ComplianceFilterBackend(DatatablesFilterBackend):
             super_queryset = super(ComplianceFilterBackend, self).filter_queryset(request, queryset, view)
 
             # Custom search 
+            #TODO: fix search
             search_text = request.GET.get('search[value]')  # This has a search term.
             if search_text:
                 email_user_ids = list(EmailUser.objects.annotate(full_name=Concat('first_name',Value(" "),'last_name',output_field=CharField()))

--- a/mooringlicensing/components/compliances/api.py
+++ b/mooringlicensing/components/compliances/api.py
@@ -30,6 +30,7 @@ from rest_framework.renderers import JSONRenderer
 from django.core.cache import cache
 from ledger_api_client.ledger_models import EmailUserRO as EmailUser
 from mooringlicensing.components.main.decorators import basic_exception_handler
+from ledger_api_client.managed_models import SystemUser
 
 # from ledger.address.models import Country
 # from datetime import datetime, timedelta, date
@@ -295,18 +296,17 @@ class ComplianceFilterBackend(DatatablesFilterBackend):
             super_queryset = super(ComplianceFilterBackend, self).filter_queryset(request, queryset, view)
 
             # Custom search 
-            #TODO: fix search
             search_text = request.GET.get('search[value]')  # This has a search term.
             if search_text:
-                email_user_ids = list(EmailUser.objects.annotate(full_name=Concat('first_name',Value(" "),'last_name',output_field=CharField()))
+                system_user_ids = list(SystemUser.objects.annotate(full_name=Concat('legal_first_name',Value(" "),'legal_last_name',output_field=CharField()))
                 .filter(
-                    Q(first_name__icontains=search_text) | Q(last_name__icontains=search_text) | Q(email__icontains=search_text) | Q(full_name__icontains=search_text)
-                ).values_list("id", flat=True))
+                    Q(legal_first_name__icontains=search_text) | Q(legal_last_name__icontains=search_text) | Q(email__icontains=search_text) | Q(full_name__icontains=search_text)
+                ).values_list("ledger_id", flat=True))
                 proposal_applicant_proposals = list(ProposalApplicant.objects.annotate(full_name=Concat('first_name',Value(" "),'last_name',output_field=CharField()))
                 .filter(
                     Q(first_name__icontains=search_text) | Q(last_name__icontains=search_text) | Q(email__icontains=search_text) | Q(full_name__icontains=search_text)
                 ).values_list("proposal_id", flat=True))
-                q_set = queryset.filter(Q(approval__current_proposal__id__in=proposal_applicant_proposals)|Q(approval__current_proposal__submitter__in=email_user_ids))
+                q_set = queryset.filter(Q(approval__current_proposal__id__in=proposal_applicant_proposals)|Q(approval__current_proposal__submitter__in=system_user_ids))
 
                 queryset = super_queryset.union(q_set)
             return queryset

--- a/mooringlicensing/components/compliances/email.py
+++ b/mooringlicensing/components/compliances/email.py
@@ -7,7 +7,6 @@ from django.urls import reverse
 from django.conf import settings
 
 from mooringlicensing.components.emails.emails import TemplateEmailBase
-# from ledger.accounts.models import EmailUser
 from ledger_api_client.ledger_models import EmailUserRO as EmailUser
 #from django.core.files.storage import default_storage
 from django.core.files.base import ContentFile
@@ -134,7 +133,7 @@ def send_reminder_email_notification(compliance, is_test=False):
         try:
             sender_user = EmailUser.objects.get(email__icontains=sender)
         except:
-            sender_user = EmailUser.objects.create(email=sender, password='', is_staff=True)
+            sender_user = EmailUser.objects.create(email=sender, password='', is_staff=True) #TODO: is this allowed?
         _log_compliance_email(msg, compliance, sender=sender_user)
         if compliance.proposal.org_applicant:
             _log_org_email(msg, compliance.proposal.org_applicant, compliance.submitter, sender=sender_user)
@@ -163,7 +162,7 @@ def send_internal_reminder_email_notification(compliance, is_test=False):
         try:
             sender_user = EmailUser.objects.get(email__icontains=sender)
         except:
-            sender_user = EmailUser.objects.create(email=sender, password='')
+            sender_user = EmailUser.objects.create(email=sender, password='') #TODO: is this allowed?
         _log_compliance_email(msg, compliance, sender=sender_user)
         if compliance.proposal.org_applicant:
             _log_org_email(msg, compliance.proposal.org_applicant, compliance.submitter, sender=sender_user)
@@ -199,7 +198,7 @@ def send_due_email_notification(compliance, is_test=False):
         try:
             sender_user = EmailUser.objects.get(email__icontains=sender)
         except:
-            sender_user = EmailUser.objects.create(email=sender, password='', is_staff=True)
+            sender_user = EmailUser.objects.create(email=sender, password='', is_staff=True) #TODO: is this allowed?
         _log_compliance_email(msg, compliance, sender=sender_user)
         if compliance.proposal.org_applicant:
             _log_org_email(msg, compliance.proposal.org_applicant, compliance.submitter, sender=sender_user)
@@ -229,7 +228,7 @@ def send_internal_due_email_notification(compliance, is_test=False):
         try:
             sender_user = EmailUser.objects.get(email__icontains=sender)
         except:
-            sender_user = EmailUser.objects.create(email=sender, password='', is_staff=True)
+            sender_user = EmailUser.objects.create(email=sender, password='', is_staff=True) #TODO: is this allowed?
         _log_compliance_email(msg, compliance, sender=sender_user)
         if compliance.proposal.org_applicant:
             _log_org_email(msg, compliance.proposal.org_applicant, compliance.submitter, sender=sender_user)

--- a/mooringlicensing/components/compliances/email.py
+++ b/mooringlicensing/components/compliances/email.py
@@ -133,7 +133,8 @@ def send_reminder_email_notification(compliance, is_test=False):
         try:
             sender_user = EmailUser.objects.get(email__icontains=sender)
         except:
-            sender_user = EmailUser.objects.create(email=sender, password='', is_staff=True) #TODO: is this allowed?
+            sender_user = None
+
         _log_compliance_email(msg, compliance, sender=sender_user)
         if compliance.proposal.org_applicant:
             _log_org_email(msg, compliance.proposal.org_applicant, compliance.submitter, sender=sender_user)
@@ -162,7 +163,8 @@ def send_internal_reminder_email_notification(compliance, is_test=False):
         try:
             sender_user = EmailUser.objects.get(email__icontains=sender)
         except:
-            sender_user = EmailUser.objects.create(email=sender, password='') #TODO: is this allowed?
+            sender_user = None
+
         _log_compliance_email(msg, compliance, sender=sender_user)
         if compliance.proposal.org_applicant:
             _log_org_email(msg, compliance.proposal.org_applicant, compliance.submitter, sender=sender_user)
@@ -198,7 +200,8 @@ def send_due_email_notification(compliance, is_test=False):
         try:
             sender_user = EmailUser.objects.get(email__icontains=sender)
         except:
-            sender_user = EmailUser.objects.create(email=sender, password='', is_staff=True) #TODO: is this allowed?
+            sender_user = None
+
         _log_compliance_email(msg, compliance, sender=sender_user)
         if compliance.proposal.org_applicant:
             _log_org_email(msg, compliance.proposal.org_applicant, compliance.submitter, sender=sender_user)
@@ -228,7 +231,7 @@ def send_internal_due_email_notification(compliance, is_test=False):
         try:
             sender_user = EmailUser.objects.get(email__icontains=sender)
         except:
-            sender_user = EmailUser.objects.create(email=sender, password='', is_staff=True) #TODO: is this allowed?
+            sender_user = None
         _log_compliance_email(msg, compliance, sender=sender_user)
         if compliance.proposal.org_applicant:
             _log_org_email(msg, compliance.proposal.org_applicant, compliance.submitter, sender=sender_user)

--- a/mooringlicensing/components/compliances/models.py
+++ b/mooringlicensing/components/compliances/models.py
@@ -5,8 +5,7 @@ from django.db import models,transaction
 from django.core.exceptions import ValidationError
 from django.utils import timezone
 from django.conf import settings
-# from ledger.accounts.models import EmailUser, RevisionedMixin
-from ledger_api_client.ledger_models import EmailUserRO as EmailUser, Invoice
+from ledger_api_client.ledger_models import Invoice
 from mooringlicensing.components.main.models import (
     CommunicationsLogEntry,  # Region,
     UserAction,
@@ -75,11 +74,9 @@ class Compliance(RevisionedMixin):
     num_participants = models.SmallIntegerField('Number of participants', blank=True, null=True)
     processing_status = models.CharField(choices=PROCESSING_STATUS_CHOICES,max_length=20)
     customer_status = models.CharField(choices=CUSTOMER_STATUS_CHOICES,max_length=20)
-    # assigned_to = models.ForeignKey(EmailUser, related_name='mooringlicensing_compliance_assignments', null=True, blank=True, on_delete=models.SET_NULL)
     assigned_to = models.IntegerField( null=True, blank=True)
     requirement = models.ForeignKey(ProposalRequirement, blank=True, null=True, related_name='compliance_requirement', on_delete=models.SET_NULL)
     lodgement_date = models.DateTimeField(blank=True, null=True)
-    # submitter = models.ForeignKey(EmailUser, blank=True, null=True, related_name='mooringlicensing_compliances', on_delete=models.SET_NULL)
     submitter = models.IntegerField(blank=True, null=True)
     reminder_sent = models.BooleanField(default=False)
     post_reminder_sent = models.BooleanField(default=False)
@@ -323,7 +320,6 @@ class CompRequest(models.Model):
     compliance = models.ForeignKey(Compliance, on_delete=models.CASCADE)
     subject = models.CharField(max_length=200, blank=True)
     text = models.TextField(blank=True)
-    # officer = models.ForeignKey(EmailUser, null=True, on_delete=models.SET_NULL)
     officer = models.IntegerField(null=True, blank=True)
 
     class Meta:

--- a/mooringlicensing/components/compliances/models.py
+++ b/mooringlicensing/components/compliances/models.py
@@ -217,7 +217,7 @@ class Compliance(RevisionedMixin):
             self.log_user_action(ComplianceUserAction.ACTION_CONCLUDE_REQUEST.format(self.id),request)
             send_compliance_accept_email_notification(self,request)
 
-    def send_reminder(self, user):
+    def send_reminder(self, user=None):
         with transaction.atomic():
             try:
                 if self.processing_status == Compliance.PROCESSING_STATUS_DUE and self.reminder_sent is False:

--- a/mooringlicensing/components/compliances/serializers.py
+++ b/mooringlicensing/components/compliances/serializers.py
@@ -1,5 +1,4 @@
 # from django.utils import timezone
-# from ledger.accounts.models import EmailUser,Address
 from ledger_api_client.managed_models import SystemUser
 from mooringlicensing.components.compliances.models import (
     Compliance, ComplianceUserAction, ComplianceLogEntry, ComplianceAmendmentRequest, ComplianceAmendmentReason

--- a/mooringlicensing/components/emails/utils.py
+++ b/mooringlicensing/components/emails/utils.py
@@ -6,8 +6,7 @@ def get_user_as_email_user(sender):
     try:
         sender_user = EmailUser.objects.get(email__icontains=sender)
     except:
-        EmailUser.objects.create(email=sender, password='') #TODO: is this allowed?
-        sender_user = EmailUser.objects.get(email__icontains=sender)
+        sender_user = None
     return sender_user
 
 

--- a/mooringlicensing/components/emails/utils.py
+++ b/mooringlicensing/components/emails/utils.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-# from ledger.accounts.models import EmailUser
 from ledger_api_client.ledger_models import EmailUserRO as EmailUser
 
 
@@ -7,7 +6,7 @@ def get_user_as_email_user(sender):
     try:
         sender_user = EmailUser.objects.get(email__icontains=sender)
     except:
-        EmailUser.objects.create(email=sender, password='')
+        EmailUser.objects.create(email=sender, password='') #TODO: is this allowed?
         sender_user = EmailUser.objects.get(email__icontains=sender)
     return sender_user
 

--- a/mooringlicensing/components/main/models.py
+++ b/mooringlicensing/components/main/models.py
@@ -6,7 +6,6 @@ import os
 from django.db import models
 # from django.utils.encoding import python_2_unicode_compatible
 from django.core.exceptions import ValidationError
-# from ledger.accounts.models import EmailUser, RevisionedMixin
 from datetime import datetime
 from django.dispatch import receiver
 from django.db.models.signals import post_save, post_delete
@@ -21,7 +20,6 @@ private_storage = FileSystemStorage(  # We want to store files in secure place (
 
 # @python_2_unicode_compatible
 class UserAction(models.Model):
-    # who = models.ForeignKey(EmailUser, null=False, blank=False)
     who = models.IntegerField(null=True, blank=True)  # EmailUserRO
     when = models.DateTimeField(null=False, blank=False, auto_now_add=True)
     what = models.TextField(blank=False)

--- a/mooringlicensing/components/main/serializers.py
+++ b/mooringlicensing/components/main/serializers.py
@@ -6,8 +6,6 @@ from mooringlicensing.components.main.models import (
         CommunicationsLogEntry,
         GlobalSettings, TemporaryDocumentCollection,
         )
-# from ledger.payments.invoice.models import Invoice
-# from ledger.accounts.models import EmailUser
 from ledger_api_client.ledger_models import EmailUserRO, Invoice
 from ledger_api_client import utils
 

--- a/mooringlicensing/components/main/utils.py
+++ b/mooringlicensing/components/main/utils.py
@@ -21,7 +21,6 @@ from mooringlicensing.components.proposals.models import (
     MooringBay,
     Mooring,
     Proposal,
-    ProposalApplicant,
     StickerPrintingBatch
 )
 from mooringlicensing.components.main.decorators import query_debugger
@@ -537,6 +536,7 @@ def reorder_wla(target_bay):
         logger.info(f'Allocation order: [{w.wla_order}] has been set to the WaitingListAllocation: [{w}].')
         place += 1
 
+#TODO remove this
 def update_personal_details(request, user_id):
     """
     Update the ledger and the proposal_applicant(s) of all the applications of this user with 'draft' status

--- a/mooringlicensing/components/main/utils.py
+++ b/mooringlicensing/components/main/utils.py
@@ -3,7 +3,6 @@ from io import BytesIO
 
 from ledger_api_client import api
 from ledger_api_client.settings_base import TIME_ZONE
-from ledger_api_client.ledger_models import EmailUserRO
 from django.utils import timezone
 from confy import env
 

--- a/mooringlicensing/components/organisations/models.py
+++ b/mooringlicensing/components/organisations/models.py
@@ -8,8 +8,6 @@ from django.db.models.signals import pre_delete
 from django.core.exceptions import ValidationError
 from django.db.models import JSONField
 from django.core.validators import MaxValueValidator, MinValueValidator
-# from ledger.accounts.models import Organisation as ledger_organisation
-# from ledger.accounts.models import EmailUser,RevisionedMixin #,Document
 from mooringlicensing.components.main.models import UserAction,CommunicationsLogEntry, Document
 from mooringlicensing.components.organisations.utils import random_generator, can_admin_org, has_atleast_one_admin
 from mooringlicensing.components.organisations.emails import (
@@ -41,7 +39,6 @@ class Organisation(models.Model):
     # organisation = models.ForeignKey(ledger_organisation)
     organisation = models.IntegerField()  # Ledger Organisation
     # TODO: business logic related to delegate changes.
-    # delegates = models.ManyToManyField(EmailUser, blank=True, through='UserDelegation', related_name='mooringlicensing_organisations')
     delegates = ArrayField(models.IntegerField(), blank=True)  # EmailUserRO
     #pin_one = models.CharField(max_length=50,blank=True)
     #pin_two = models.CharField(max_length=50,blank=True)
@@ -529,7 +526,6 @@ class OrganisationContact(models.Model):
 
 class UserDelegation(models.Model):
     organisation = models.ForeignKey(Organisation, on_delete=models.CASCADE)
-    # user = models.ForeignKey(EmailUser)
     user = models.IntegerField()  # EmailUserRO
 
     class Meta:
@@ -618,9 +614,7 @@ class OrganisationRequest(models.Model):
     )
     name = models.CharField(max_length=128)
     abn = models.CharField(max_length=50, null=True, blank=True, verbose_name='ABN')
-    # requester = models.ForeignKey(EmailUser)
     requester = models.IntegerField()  # EmailUserRO
-    # assigned_officer = models.ForeignKey(EmailUser, blank=True, null=True, related_name='org_request_assignee')
     assigned_officer = models.IntegerField(null=True, blank=True)  # EmailUserRO
     identification = models.FileField(storage=private_storage,upload_to='organisation/requests/%Y/%m/%d', max_length=512, null=True, blank=True)
     status = models.CharField(max_length=100,choices=STATUS_CHOICES, default="with_assessor")
@@ -723,8 +717,6 @@ class OrganisationRequest(models.Model):
         return OrganisationRequestUserAction.log_action(self, action, request.user)
 
 class OrganisationAccessGroup(models.Model):
-    # site = models.OneToOneField(Site, default='1')
-    # members = models.ManyToManyField(EmailUser)
     members = ArrayField(models.IntegerField(), blank=True)  # EmailUserRO
 
     def __str__(self):
@@ -735,7 +727,6 @@ class OrganisationAccessGroup(models.Model):
         all_members = []
         all_members.extend(self.members.all())
         member_ids = [m.id for m in self.members.all()]
-        #all_members.extend(EmailUser.objects.filter(is_superuser=True,is_staff=True,is_active=True).exclude(id__in=member_ids))
         return all_members
 
     @property
@@ -771,7 +762,6 @@ class OrganisationRequestUserAction(UserAction):
 
 class OrganisationRequestDeclinedDetails(models.Model):
     request = models.ForeignKey(OrganisationRequest, on_delete=models.CASCADE)
-    # officer = models.ForeignKey(EmailUser, null=False)
     officer = models.IntegerField(null=False, blank=False)  # EmailUserRO
     reason = models.TextField(blank=True)
 

--- a/mooringlicensing/components/organisations/serializers.py
+++ b/mooringlicensing/components/organisations/serializers.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-# from ledger.accounts.models import EmailUser,OrganisationAddress
 from ledger_api_client.ledger_models import EmailUserRO as EmailUser
 from mooringlicensing.components.organisations.models import (
                                 Organisation,
@@ -86,20 +85,9 @@ class OrganisationAddressSerializer(serializers.ModelSerializer):
     #         'postcode'
     #     )
 
-class DelegateSerializer(serializers.ModelSerializer):
-    name = serializers.CharField(source='get_full_name')
-    class Meta:
-        model = EmailUser
-        fields = (
-            'id',
-            'name',
-            'email',
-        )
-
 class OrganisationSerializer(serializers.ModelSerializer):
     address = OrganisationAddressSerializer(read_only=True)
     pins = serializers.SerializerMethodField(read_only=True)
-    #delegates = DelegateSerializer(many=True, read_only=True)
     delegates = serializers.SerializerMethodField(read_only=True)
     organisation = LedgerOrganisationSerializer()
     trading_name = serializers.SerializerMethodField(read_only=True)
@@ -141,9 +129,6 @@ class OrganisationSerializer(serializers.ModelSerializer):
         return obj.licence_discount
 
     def get_delegates(self, obj):
-        """
-        Default DelegateSerializer does not include whether the user is an organisation admin, so adding it here
-        """
         delegates = []
         for user in obj.delegates.all():
             admin_qs = obj.contacts.filter(organisation__organisation_id=obj.organisation_id, email=user.email, is_admin=True, user_role='organisation_admin') #.values_list('is_admin',flat=True)

--- a/mooringlicensing/components/payments_ml/models.py
+++ b/mooringlicensing/components/payments_ml/models.py
@@ -9,9 +9,7 @@ from dateutil.relativedelta import relativedelta
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Min
-# from ledger.accounts.models import RevisionedMixin, EmailUser
-# from ledger.payments.invoice.models import Invoice
-from ledger_api_client.ledger_models import EmailUserRO as EmailUser, Invoice
+from ledger_api_client.ledger_models import Invoice
 # from ledger.settings_base import TIME_ZONE
 from mooringlicensing.settings import TIME_ZONE
 
@@ -106,7 +104,6 @@ class DcvAdmissionFee(Payment):
     dcv_admission = models.ForeignKey('DcvAdmission', on_delete=models.CASCADE, blank=True, null=True, related_name='dcv_admission_fees')
     payment_type = models.SmallIntegerField(choices=PAYMENT_TYPE_CHOICES, default=0)
     cost = models.DecimalField(max_digits=8, decimal_places=2, default='0.00')
-    # created_by = models.ForeignKey(EmailUser, on_delete=models.PROTECT, blank=True, null=True, related_name='created_by_dcv_admission_fee')
     created_by = models.IntegerField(blank=True, null=True)
     invoice_reference = models.CharField(max_length=50, null=True, blank=True, default='')
     fee_items = models.ManyToManyField('FeeItem', related_name='dcv_admission_fees')
@@ -146,7 +143,6 @@ class DcvPermitFee(Payment):
     dcv_permit = models.ForeignKey('DcvPermit', on_delete=models.CASCADE, blank=True, null=True, related_name='dcv_permit_fees')
     payment_type = models.SmallIntegerField(choices=PAYMENT_TYPE_CHOICES, default=0)
     cost = models.DecimalField(max_digits=8, decimal_places=2, default='0.00')
-    # created_by = models.ForeignKey(EmailUser, on_delete=models.PROTECT, blank=True, null=True, related_name='created_by_dcv_permit_fee')
     created_by = models.IntegerField(blank=True, null=True)
     invoice_reference = models.CharField(max_length=50, null=True, blank=True, default='')
     fee_items = models.ManyToManyField('FeeItem', related_name='dcv_permit_fees')
@@ -185,7 +181,6 @@ class StickerActionFee(Payment):
 
     payment_type = models.SmallIntegerField(choices=PAYMENT_TYPE_CHOICES, default=0)
     cost = models.DecimalField(max_digits=8, decimal_places=2, default='0.00')
-    # created_by = models.ForeignKey(EmailUser,on_delete=models.PROTECT, blank=True, null=True,)
     created_by = models.IntegerField(blank=True, null=True,)
     invoice_reference = models.CharField(max_length=50, null=True, blank=True, default='')
     uuid = models.CharField(max_length=36, blank=True, null=True)
@@ -251,7 +246,6 @@ class ApplicationFee(Payment):
     proposal = models.ForeignKey('Proposal', on_delete=models.CASCADE, blank=True, null=True, related_name='application_fees')
     payment_type = models.SmallIntegerField(choices=PAYMENT_TYPE_CHOICES, default=0)
     cost = models.DecimalField(max_digits=8, decimal_places=2, default='0.00')
-    # created_by = models.ForeignKey(EmailUser,on_delete=models.PROTECT, blank=True, null=True,related_name='created_by_application_fee')
     created_by = models.IntegerField(blank=True, null=True)
     invoice_reference = models.CharField(max_length=50, null=True, blank=True, default='')
     fee_items = models.ManyToManyField('FeeItem', related_name='application_fees', through='FeeItemApplicationFee')

--- a/mooringlicensing/components/proposals/api.py
+++ b/mooringlicensing/components/proposals/api.py
@@ -21,8 +21,7 @@ from rest_framework.renderers import JSONRenderer
 from datetime import datetime
 # from ledger.settings_base import TIME_ZONE
 from ledger_api_client.settings_base import TIME_ZONE, LOGGING
-# from ledger.accounts.models import EmailUser, Address
-from ledger_api_client.ledger_models import EmailUserRO as EmailUser, Address
+from ledger_api_client.ledger_models import EmailUserRO as EmailUser
 from ledger_api_client import api
 from mooringlicensing import settings
 from mooringlicensing.components.main.models import GlobalSettings
@@ -518,6 +517,7 @@ class ProposalFilterBackend(DatatablesFilterBackend):
         setattr(view, '_datatables_total_count', total_count)
 
         search_text = request.GET.get('search[value]')
+        #TODO: fix search
         if search_text:
             #the search conducted by the superclass only accomodates the ProposalApplicant users
             #this misses any new draft proposals, which do not yet have a ProposalApplicant record assigned - so we will do that here
@@ -2360,6 +2360,7 @@ class MooringFilterBackend(DatatablesFilterBackend):
             super_queryset = super(MooringFilterBackend, self).filter_queryset(request, queryset, view)
 
             # Custom search
+            #TODO: fix search
             search_text = request.GET.get('search[value]')  # This has a search term.
             if search_text:
                 # email_user_ids = EmailUser.objects.filter(Q(first_name__icontains=search_term) | Q(last_name__icontains=search_term) | Q(email__icontains=search_term)).values_list('id', flat=True)

--- a/mooringlicensing/components/proposals/api.py
+++ b/mooringlicensing/components/proposals/api.py
@@ -1507,6 +1507,16 @@ class ProposalViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
             is_authorised_to_modify(request, instance)
             save_proponent_data(instance,request,self)
             return redirect(reverse('external'))
+        
+    @detail_route(methods=['post'], detail=True)
+    @renderer_classes((JSONRenderer,))
+    @basic_exception_handler
+    def internal_save(self, request, *args, **kwargs):
+        with transaction.atomic():
+            instance = self.get_object()
+
+            save_proponent_data(instance,request,self)
+            return redirect(reverse('internal'))
 
     @detail_route(methods=['post'], detail=True)
     @renderer_classes((JSONRenderer,))

--- a/mooringlicensing/components/proposals/api.py
+++ b/mooringlicensing/components/proposals/api.py
@@ -1512,11 +1512,12 @@ class ProposalViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
     @renderer_classes((JSONRenderer,))
     @basic_exception_handler
     def internal_save(self, request, *args, **kwargs):
-        with transaction.atomic():
-            instance = self.get_object()
+        if (is_internal(request)): #TODO: better auth, using groups/permissions
+            with transaction.atomic():
+                instance = self.get_object()
 
-            save_proponent_data(instance,request,self)
-            return redirect(reverse('internal'))
+                save_proponent_data(instance,request,self)
+                return redirect(reverse('internal'))
 
     @detail_route(methods=['post'], detail=True)
     @renderer_classes((JSONRenderer,))

--- a/mooringlicensing/components/proposals/api.py
+++ b/mooringlicensing/components/proposals/api.py
@@ -107,7 +107,6 @@ from mooringlicensing.components.main.decorators import (
         timeit, 
         query_debugger
         )
-from mooringlicensing.components.users.serializers import ProposalApplicantSerializer
 from mooringlicensing.helpers import is_authorised_to_modify, is_customer, is_internal, is_applicant_address_set
 from rest_framework_datatables.pagination import DatatablesPageNumberPagination
 from rest_framework_datatables.filters import DatatablesFilterBackend

--- a/mooringlicensing/components/proposals/email.py
+++ b/mooringlicensing/components/proposals/email.py
@@ -33,7 +33,7 @@ def log_proposal_email(msg, proposal, sender, attachments=[]):
     try:
         sender_user = sender if isinstance(sender, EmailUser) else EmailUser.objects.get(email__icontains=sender)
     except:
-        sender_user = EmailUser.objects.create(email=sender, password='') #TODO: is this allowed?
+        sender_user = None
 
     _log_proposal_email(msg, proposal, sender=sender_user, attachments=attachments)
     if proposal.org_applicant:
@@ -303,8 +303,7 @@ def send_create_mooring_licence_application_email_notification(request, waiting_
     try:
         sender_user = EmailUser.objects.get(email__icontains=sender)
     except:
-        EmailUser.objects.create(email=sender, password='') #TODO: is this allowed?
-        sender_user = EmailUser.objects.get(email__icontains=sender)
+        sender_user = None
 
     attachments = []
     if waiting_list_allocation.waiting_list_offer_documents.all():
@@ -639,8 +638,7 @@ def send_approval_renewal_email_notification(approval):
     try:
         sender_user = EmailUser.objects.get(email__icontains=sender)
     except:
-        EmailUser.objects.create(email=sender, password='') #TODO: is this allowed?
-        sender_user = EmailUser.objects.get(email__icontains=sender)
+        sender_user = None
 
     attachments = []
     attachment = approval.get_licence_document_as_attachment()

--- a/mooringlicensing/components/proposals/email.py
+++ b/mooringlicensing/components/proposals/email.py
@@ -2,8 +2,6 @@ import logging
 import mimetypes
 import pytz
 import requests
-# from ledger.accounts.models import EmailUser
-# from ledger.payments.invoice.models import Invoice
 from ledger_api_client.ledger_models import EmailUserRO as EmailUser, Invoice
 
 from django.core.mail import EmailMultiAlternatives, EmailMessage
@@ -35,7 +33,7 @@ def log_proposal_email(msg, proposal, sender, attachments=[]):
     try:
         sender_user = sender if isinstance(sender, EmailUser) else EmailUser.objects.get(email__icontains=sender)
     except:
-        sender_user = EmailUser.objects.create(email=sender, password='')
+        sender_user = EmailUser.objects.create(email=sender, password='') #TODO: is this allowed?
 
     _log_proposal_email(msg, proposal, sender=sender_user, attachments=attachments)
     if proposal.org_applicant:
@@ -305,7 +303,7 @@ def send_create_mooring_licence_application_email_notification(request, waiting_
     try:
         sender_user = EmailUser.objects.get(email__icontains=sender)
     except:
-        EmailUser.objects.create(email=sender, password='')
+        EmailUser.objects.create(email=sender, password='') #TODO: is this allowed?
         sender_user = EmailUser.objects.get(email__icontains=sender)
 
     attachments = []
@@ -641,7 +639,7 @@ def send_approval_renewal_email_notification(approval):
     try:
         sender_user = EmailUser.objects.get(email__icontains=sender)
     except:
-        EmailUser.objects.create(email=sender, password='')
+        EmailUser.objects.create(email=sender, password='') #TODO: is this allowed?
         sender_user = EmailUser.objects.get(email__icontains=sender)
 
     attachments = []

--- a/mooringlicensing/components/proposals/forms.py
+++ b/mooringlicensing/components/proposals/forms.py
@@ -1,6 +1,5 @@
 from django import forms
 from django.core.exceptions import ValidationError
-# from ledger.accounts.models import EmailUser
 from mooringlicensing.components.proposals.models import HelpPage #ProposalAssessorGroup,ProposalApproverGroup
 from mooringlicensing.components.main.models import SystemMaintenance
 from ckeditor.widgets import CKEditorWidget

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -1214,7 +1214,7 @@ class Proposal(DirtyFieldsMixin, RevisionedMixin):
         return self.child_obj.is_approver(user)
 
     def can_assess(self, user):
-        if self.processing_status in [Proposal.PROCESSING_STATUS_WITH_ASSESSOR, Proposal.PROCESSING_STATUS_WITH_ASSESSOR_REQUIREMENTS]:
+        if self.processing_status in [Proposal.PROCESSING_STATUS_WITH_ASSESSOR, Proposal.PROCESSING_STATUS_WITH_ASSESSOR_REQUIREMENTS,Proposal.PROCESSING_STATUS_DRAFT]:
             return self.child_obj.is_assessor(user)
         elif self.processing_status in [Proposal.PROCESSING_STATUS_WITH_APPROVER, Proposal.PROCESSING_STATUS_AWAITING_PAYMENT, Proposal.PROCESSING_STATUS_PRINTING_STICKER]:
             return self.child_obj.is_approver(user)
@@ -1242,7 +1242,7 @@ class Proposal(DirtyFieldsMixin, RevisionedMixin):
         if isinstance(user, EmailUserRO):
             user = user.id
 
-        status_without_assessor = [Proposal.PROCESSING_STATUS_WITH_APPROVER, Proposal.PROCESSING_STATUS_APPROVED, Proposal.PROCESSING_STATUS_AWAITING_PAYMENT, Proposal.PROCESSING_STATUS_DECLINED, Proposal.PROCESSING_STATUS_DRAFT]
+        status_without_assessor = [Proposal.PROCESSING_STATUS_WITH_APPROVER, Proposal.PROCESSING_STATUS_APPROVED, Proposal.PROCESSING_STATUS_AWAITING_PAYMENT, Proposal.PROCESSING_STATUS_DECLINED]
         if self.processing_status in status_without_assessor:
             return False
         else:

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -184,15 +184,6 @@ class ProposalType(RevisionedMixin):
         app_label = 'mooringlicensing'
 
 
-# class ProposalApplicantDetails(models.Model):
-#     '''
-#     This model is for storing the historical applicant details
-#     '''
-#     details = models.JSONField(blank=True, null=True)
-#
-#     class Meta:
-#         app_label = 'mooringlicensing'
-
 class ProposalProofOfIdentityDocument(models.Model):
     proof_of_identity_document = models.ForeignKey('ProofOfIdentityDocument', on_delete=models.CASCADE)
     proposal = models.ForeignKey('Proposal', on_delete=models.CASCADE)

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -1236,6 +1236,22 @@ class Proposal(DirtyFieldsMixin, RevisionedMixin):
         else:
             return False
 
+    def has_approver_mode(self,user):
+        if isinstance(user, EmailUserRO):
+            user = user.id
+
+        status_without_approver = [Proposal.PROCESSING_STATUS_WITH_ASSESSOR, Proposal.PROCESSING_STATUS_APPROVED, Proposal.PROCESSING_STATUS_AWAITING_PAYMENT, Proposal.PROCESSING_STATUS_DECLINED, Proposal.PROCESSING_STATUS_DRAFT]
+        if self.processing_status in status_without_approver:
+            return False
+        else:
+            if self.assigned_officer:
+                if self.assigned_officer == user:
+                    return self.child_obj.is_approver(user)
+                else:
+                    return False
+            else:
+                return self.child_obj.is_approver(user)
+
     def has_assessor_mode(self,user):
         # status_without_assessor = ['with_approver','approved','awaiting_payment','declined','draft']
         if isinstance(user, EmailUserRO):

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -38,9 +38,7 @@ from django.utils import timezone
 # from django.conf import settings
 # from django.core.urlresolvers import reverse
 from django.urls import reverse
-# from ledger.accounts.models import EmailUser, RevisionedMixin
-from ledger_api_client.ledger_models import EmailUserRO as EmailUser, EmailUserRO, BaseAddress
-# from ledger.payments.invoice.models import Invoice
+from ledger_api_client.ledger_models import EmailUserRO
 from ledger_api_client.ledger_models import Invoice
 from mooringlicensing import exceptions, settings
 from mooringlicensing.components.organisations.models import Organisation

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -328,14 +328,10 @@ class Proposal(DirtyFieldsMixin, RevisionedMixin):
     lodgement_sequence = models.IntegerField(blank=True, default=0)
     lodgement_date = models.DateTimeField(blank=True, null=True)
 
-    # proxy_applicant = models.ForeignKey(EmailUser, blank=True, null=True, related_name='mooringlicensing_proxy', on_delete=models.SET_NULL) # not currently used by ML
     proxy_applicant = models.IntegerField(blank=True, null=True) # not currently used by ML
-    # submitter = models.ForeignKey(EmailUser, blank=True, null=True, related_name='mooringlicensing_proposals', on_delete=models.SET_NULL)
     submitter = models.IntegerField(blank=True, null=True)
 
-    # assigned_officer = models.ForeignKey(EmailUser, blank=True, null=True, related_name='mooringlicensing_proposals_assigned', on_delete=models.SET_NULL)
     assigned_officer = models.IntegerField(blank=True, null=True)
-    # assigned_approver = models.ForeignKey(EmailUser, blank=True, null=True, related_name='mooringlicensing_proposals_approvals', on_delete=models.SET_NULL)
     assigned_approver = models.IntegerField(blank=True, null=True)
     processing_status = models.CharField('Processing Status', max_length=40, choices=PROCESSING_STATUS_CHOICES,
                                          default=PROCESSING_STATUS_CHOICES[0][0])
@@ -4787,7 +4783,6 @@ class VesselRegistrationDocument(Document):
         return ret_str
 
 class Owner(RevisionedMixin):
-    # emailuser = models.OneToOneField(EmailUser, on_delete=models.CASCADE)
     emailuser = models.IntegerField(unique=True)  # unique=True keeps the OneToOne relation
     # add on approval only
     vessels = models.ManyToManyField(Vessel, through=VesselOwnership) # these owner/vessel association
@@ -4889,7 +4884,6 @@ class ElectoralRollDocument(Document):
         proposal_id = self.proposal.id
         return self.relative_path_to_file(proposal_id, filename)
 
-    #emailuser = models.ForeignKey(EmailUser,related_name='electoral_roll_documents')
     proposal = models.ForeignKey(Proposal,related_name='electoral_roll_documents', on_delete=models.CASCADE)
     # _file = models.FileField(max_length=512)
     _file = models.FileField(
@@ -5023,7 +5017,6 @@ class ProposalRequest(models.Model):
     proposal = models.ForeignKey(Proposal, related_name='proposalrequest_set', on_delete=models.CASCADE)
     subject = models.CharField(max_length=200, blank=True)
     text = models.TextField(blank=True)
-    # officer = models.ForeignKey(EmailUser, null=True, on_delete=models.SET_NULL)
     officer = models.IntegerField(null=True, blank=True)
 
     def __str__(self):
@@ -5102,7 +5095,6 @@ class AmendmentRequest(ProposalRequest):
 
 class ProposalDeclinedDetails(models.Model):
     proposal = models.OneToOneField(Proposal, null=True, on_delete=models.SET_NULL)
-    # officer = models.ForeignKey(EmailUser, null=True, on_delete=models.SET_NULL)
     officer = models.IntegerField(null=True, blank=True)
     reason = models.TextField(blank=True)
     cc_email = models.TextField(null=True)
@@ -5208,7 +5200,6 @@ class ProposalUserAction(UserAction):
             what=str(action)
         )
 
-    # who = models.ForeignKey(EmailUser, null=True, blank=True, on_delete=models.SET_NULL)
     who = models.IntegerField(null=True, blank=True)
     when = models.DateTimeField(null=False, blank=False, auto_now_add=True)
     what = models.TextField(blank=False)

--- a/mooringlicensing/components/proposals/serializers.py
+++ b/mooringlicensing/components/proposals/serializers.py
@@ -8,9 +8,7 @@ from decimal import Decimal
 from math import ceil
 
 from django.conf import settings
-# from ledger.accounts.models import EmailUser,Address
-# from ledger.payments.invoice.models import Invoice
-from ledger_api_client.ledger_models import EmailUserRO as EmailUser, Invoice, Address
+from ledger_api_client.ledger_models import EmailUserRO as EmailUser, Invoice
 
 from mooringlicensing.components.main.models import ApplicationType
 # from mooringlicensing.components.main.utils import retrieve_email_user
@@ -50,24 +48,6 @@ from mooringlicensing.ledger_api_utils import retrieve_system_user
 
 # logger = logging.getLogger('mooringlicensing')
 logger = logging.getLogger(__name__)
-
-
-class EmailUserAppViewSerializer(serializers.ModelSerializer):
-    residential_address = UserAddressSerializer()
-
-    class Meta:
-        model = EmailUser
-        fields = ('id',
-                  'email',
-                  'first_name',
-                  'last_name',
-                  'dob',
-                  'title',
-                  'organisation',
-                  'residential_address',
-                  'email',
-                  'phone_number',
-                  'mobile_number',)
 
 
 class ProposalTypeSerializer(serializers.ModelSerializer):

--- a/mooringlicensing/components/proposals/serializers.py
+++ b/mooringlicensing/components/proposals/serializers.py
@@ -693,7 +693,7 @@ class SaveWaitingListApplicationSerializer(serializers.ModelSerializer):
                 'silent_elector',
                 'temporary_document_collection_id',
                 'keep_existing_vessel',
-                'auto_approve',
+                'auto_approve', #TODO: if auto approve is supposed to be strictly based on other values we should NOT let the client set it
                 )
         read_only_fields=('id',)
 

--- a/mooringlicensing/components/proposals/serializers.py
+++ b/mooringlicensing/components/proposals/serializers.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 from math import ceil
 
 from django.conf import settings
-from ledger_api_client.ledger_models import EmailUserRO as EmailUser, Invoice
+from ledger_api_client.ledger_models import Invoice
 
 from mooringlicensing.components.main.models import ApplicationType
 # from mooringlicensing.components.main.utils import retrieve_email_user

--- a/mooringlicensing/components/proposals/serializers.py
+++ b/mooringlicensing/components/proposals/serializers.py
@@ -1057,7 +1057,9 @@ class InternalProposalSerializer(BaseProposalSerializer):
     def get_allowed_assessors(self, obj):
         if 'request' in self.context and is_internal(self.context['request']):
             email_user_ids = list(obj.allowed_assessors.values_list("id",flat=True))
+            print("EMAIL USER IDS",email_user_ids)
             system_users = SystemUser.objects.filter(ledger_id__id__in=email_user_ids)
+            print(system_users.count())
             serializer = UserSerializer(system_users, many=True)
             return serializer.data
         else:

--- a/mooringlicensing/components/proposals/utils.py
+++ b/mooringlicensing/components/proposals/utils.py
@@ -470,7 +470,9 @@ def save_proponent_data_aua(instance, request, viewset):
     if vessel_data:
         if viewset.action == 'submit':
             submit_vessel_data(instance, request, vessel_data)
-        elif instance.processing_status == Proposal.PROCESSING_STATUS_DRAFT:
+        elif (instance.processing_status == Proposal.PROCESSING_STATUS_DRAFT or
+              instance.has_assessor_mode(request.user) or 
+              instance.has_approver_mode(request.user)):
             save_vessel_data(instance, request, vessel_data)
     # proposal
     proposal_data = request.data.get('proposal') if request.data.get('proposal') else {}

--- a/mooringlicensing/components/proposals/utils.py
+++ b/mooringlicensing/components/proposals/utils.py
@@ -1029,7 +1029,10 @@ def update_proposal_applicant(proposal, request):
     if proposal_applicant_data:
         proposal_applicant.first_name = proposal_applicant_data['legal_first_name']
         proposal_applicant.last_name = proposal_applicant_data['legal_last_name']
-        correct_date = datetime.datetime.strptime(proposal_applicant_data['legal_dob'], '%d/%m/%Y').date()
+        try:
+            correct_date = datetime.datetime.strptime(proposal_applicant_data['legal_dob'], '%d/%m/%Y').date()
+        except:
+            raise serializers.ValidationError("Incorrect date format for legal date of birth - please update this user's profile")
         proposal_applicant.dob = correct_date
  
         if 'residential_address' in proposal_applicant_data:

--- a/mooringlicensing/components/proposals/utils.py
+++ b/mooringlicensing/components/proposals/utils.py
@@ -6,7 +6,6 @@ from decimal import Decimal
 
 from django.db import transaction
 from django.http import HttpResponse
-# from ledger.accounts.models import EmailUser
 from ledger_api_client.ledger_models import EmailUserRO as EmailUser
 
 from mooringlicensing import settings
@@ -162,6 +161,7 @@ class AssessorDataSearch(object):
         for k in post_data:
             if re.match(item,k):
                 values.append({k:post_data[k]})
+        #TODO: fix search
         if values:
             for v in values:
                 for k,v in v.items():

--- a/mooringlicensing/components/proposals/utils.py
+++ b/mooringlicensing/components/proposals/utils.py
@@ -350,16 +350,17 @@ def save_proponent_data(instance, request, viewset):
     elif type(instance.child_obj) == MooringLicenceApplication:
         save_proponent_data_mla(instance, request, viewset)
 
-    # Save request.user details in a JSONField not to overwrite the details of it.
-    try:
-        user = SystemUser.objects.get(ledger_id=request.user)
-        serializer = UserSerializer(user, context={'request':request})
-        if instance:
-            instance.personal_details = serializer.data
-            instance.save()
-    except Exception as e:
-        print(e)
-        raise serializers.ValidationError("error")
+    if instance.submitter == request.user:
+        # Save request.user details in a JSONField not to overwrite the details of it.
+        try:
+            user = SystemUser.objects.get(ledger_id=request.user)
+            serializer = UserSerializer(user, context={'request':request})
+            if instance:
+                instance.personal_details = serializer.data
+                instance.save()
+        except Exception as e:
+            print(e)
+            raise serializers.ValidationError("error")
 
 
 def save_proponent_data_aaa(instance, request, viewset):

--- a/mooringlicensing/components/users/models.py
+++ b/mooringlicensing/components/users/models.py
@@ -12,7 +12,6 @@ private_storage = FileSystemStorage(  # We want to store files in secure place (
 )
 
 class EmailUserLogEntry(CommunicationsLogEntry):
-    # emailuser = models.ForeignKey(EmailUser, related_name='comms_logs')
     email_user_id = models.IntegerField(null=True, blank=True)
 
     def __init__(self, *args, **kwargs):

--- a/mooringlicensing/components/users/utils.py
+++ b/mooringlicensing/components/users/utils.py
@@ -25,7 +25,6 @@ def get_user_name(user):
     return names
 
 def _log_user_email(email_message, target_email_user, customer, sender=None, attachments=[]):
-    # from ledger.accounts.models import EmailUserLogEntry
     if isinstance(email_message, (EmailMultiAlternatives, EmailMessage,)):
         # TODO this will log the plain text body, should we log the html instead
         text = email_message.body

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/applicant.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/applicant.vue
@@ -409,8 +409,12 @@ export default {
         },
         adjust_table_width: function() {
             let vm = this;
-            vm.$refs.residential_address_datatable.vmDataTable.columns.adjust().responsive.recalc();
-            vm.$refs.postal_address_datatable.vmDataTable.columns.adjust().responsive.recalc();
+            if (vm.$refs.residential_address_datatable !== undefined) {
+                vm.$refs.postal_address_datatable.vmDataTable.columns.adjust().responsive.recalc();
+            }
+            if (vm.$refs.residential_address_datatable !== undefined) {
+                vm.$refs.postal_address_datatable.vmDataTable.columns.adjust().responsive.recalc();
+            }
         },
         datatable_options: function(address_type){
             let vm = this;

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/applicant.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/applicant.vue
@@ -18,7 +18,7 @@
                                 <div v-if="!proposalApplicant" class="form-group">
                                     <label for="" class="col-sm-3 control-label"></label>
                                     <div class="col-sm-6">
-                                        <b>To update this account please <a class="btn btn-primary" target="_blank" href="">click here</a></b>
+                                        <b>To update this account please <a class="btn btn-primary" target="_blank" :href="'/ledger-ui/accounts-management/'+user.id+'/change/'">click here</a></b>
                                     </div>
                                 </div>
 

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/applicant.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/applicant.vue
@@ -13,7 +13,15 @@
                             </h3>
                         </div>
                         <div class="panel-body panel-collapse collapse in" :id="detailsBody">
+
                             <form class="form-horizontal">
+                                <div v-if="!proposalApplicant" class="form-group">
+                                    <label for="" class="col-sm-3 control-label"></label>
+                                    <div class="col-sm-6">
+                                        <b>To update this account please <a class="btn btn-primary" target="_blank" href="">click here</a></b>
+                                    </div>
+                                </div>
+
                                 <div class="form-group">
                                     <label for="" class="col-sm-3 control-label">Given Name(s)</label>
                                     <div class="col-sm-6">

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/workflow.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/workflow.vue
@@ -23,7 +23,7 @@
                                                 class="form-control" 
                                                 v-model="proposal.assigned_approver"
                                                 @change="assignTo()">
-                                                <option v-for="member in proposal.allowed_assessors" :value="member.id">{{ member.first_name }} {{ member.last_name }}</option>
+                                                <option v-for="member in proposal.allowed_assessors" :value="member.ledger_id">{{ member.first_name }} {{ member.last_name }}</option>
                                             </select>
                                             <a v-if="canAssess && proposal.assigned_approver != proposal.current_assessor.id" @click.prevent="assignRequestUser()" class="actionBtn pull-right">Assign to me</a>
                                     </template>
@@ -34,7 +34,7 @@
                                                 class="form-control" 
                                                 v-model="proposal.assigned_officer"
                                                 @change="assignTo()">
-                                                <option v-for="member in proposal.allowed_assessors" :value="member.id">{{ member.first_name }} {{ member.last_name }}</option>
+                                                <option v-for="member in proposal.allowed_assessors" :value="member.ledger_id">{{ member.first_name }} {{ member.last_name }}</option>
                                             </select>
                                             <a v-if="canAssess && proposal.assigned_officer != proposal.current_assessor.id" @click.prevent="assignRequestUser()" class="actionBtn pull-right">Assign to me</a>
                                     </template>

--- a/mooringlicensing/frontend/mooringlicensing/src/components/form_aaa.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/form_aaa.vue
@@ -36,7 +36,6 @@
             </ul>
             <div class="tab-content" id="pills-tabContent">
               <div class="tab-pane fade" id="pills-applicant" role="tabpanel" aria-labelledby="pills-applicant-tab">
-                  <div v-if="is_external">
                     <Profile
                         :isApplication="true"
                         v-if="applicantType == 'SUB'"
@@ -49,17 +48,6 @@
                         :submitterId="submitterId"
                         :is_internal=is_internal
                     />
-                  </div>
-                  <div v-else>
-                    <Applicant
-                        :user="proposal.submitter" 
-                        :applicantType="proposal.applicant_type" 
-                        id="proposalStartApplicant"
-                        :readonly="readonly"
-                        :proposalId="proposal.id"
-                        :proposalApplicant="proposal.proposal_applicant"
-                    />
-                  </div>
               </div>
               <div class="tab-pane fade" id="pills-vessels" role="tabpanel" aria-labelledby="pills-vessels-tab">
                   <div v-if="proposal">

--- a/mooringlicensing/frontend/mooringlicensing/src/components/form_aua.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/form_aua.vue
@@ -40,7 +40,6 @@
             </ul>
             <div class="tab-content" id="pills-tabContent">
               <div class="tab-pane fade" id="pills-applicant" role="tabpanel" aria-labelledby="pills-applicant-tab">
-                  <div v-if="is_external">
                     <Profile
                         :isApplication="true"
                         v-if="applicantType == 'SUB'"
@@ -54,17 +53,6 @@
                         :forEndorser="forEndorser"
                         :is_internal=is_internal
                     />
-                  </div>
-                  <div v-else>
-                    <Applicant
-                        :user="proposal.submitter"
-                        :applicantType="proposal.applicant_type"
-                        id="proposalStartApplicant"
-                        :readonly="readonly"
-                        :proposalId="proposal.id"
-                        :proposalApplicant="proposal.proposal_applicant"
-                    />
-                  </div>
               </div>
               <div class="tab-pane fade" id="pills-vessels" role="tabpanel" aria-labelledby="pills-vessels-tab">
                   <div v-if="proposal">

--- a/mooringlicensing/frontend/mooringlicensing/src/components/form_mla.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/form_mla.vue
@@ -39,7 +39,6 @@
             </ul>
             <div class="tab-content" id="pills-tabContent">
               <div class="tab-pane fade" id="pills-applicant" role="tabpanel" aria-labelledby="pills-applicant-tab">
-                  <div v-if="is_external">
                     <Profile
                         :isApplication="true"
                         v-if="applicantType == 'SUB'"
@@ -53,19 +52,6 @@
                         :submitterId="submitterId"
                         :is_internal=is_internal
                     />
-                  </div>
-                  <div v-else>
-                    <Applicant
-                        :user="proposal.submitter"
-                        :applicantType="proposal.applicant_type"
-                        id="proposalStartApplicant"
-                        :readonly="readonly"
-                        :showElectoralRoll="showElectoralRoll"
-                        :storedSilentElector="silentElector"
-                        :proposalId="proposal.id"
-                        :proposalApplicant="proposal.proposal_applicant"
-                    />
-                  </div>
               </div>
               <div class="tab-pane fade" id="pills-vessels" role="tabpanel" aria-labelledby="pills-vessels-tab">
                   <div v-if="proposal">

--- a/mooringlicensing/frontend/mooringlicensing/src/components/form_wla.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/form_wla.vue
@@ -40,33 +40,19 @@
             </ul>
             <div class="tab-content" id="pills-tabContent">
                 <div class="tab-pane fade" id="pills-applicant" role="tabpanel" aria-labelledby="pills-applicant-tab">
-                    <div v-if="is_external">
-                        <Profile 
-                            v-if="applicantType=='SUB'"
-                            ref="profile"
-                            :isApplication="true"
-                            @profile-fetched="populateProfile"
-                            :showElectoralRoll="showElectoralRoll"
-                            :storedSilentElector="silentElector"
-                            :proposalId="proposal.id"
-                            :proposal="proposal"
-                            :readonly="readonly"
-                            :submitterId="submitterId"
-                            :is_internal=is_internal
-                        />
-                    </div>
-                    <div v-else>
-                        <Applicant 
-                            :user="proposal.submitter" 
-                            :applicantType="proposal.applicant_type"
-                            id="proposalStartApplicant" 
-                            :readonly="readonly" 
-                            :showElectoralRoll="showElectoralRoll"
-                            :storedSilentElector="silentElector" 
-                            :proposalId="proposal.id"
-                            :proposalApplicant="proposal.proposal_applicant"
-                        />
-                    </div>
+                    <Profile 
+                        v-if="applicantType=='SUB'"
+                        ref="profile"
+                        :isApplication="true"
+                        @profile-fetched="populateProfile"
+                        :showElectoralRoll="showElectoralRoll"
+                        :storedSilentElector="silentElector"
+                        :proposalId="proposal.id"
+                        :proposal="proposal"
+                        :readonly="readonly"
+                        :submitterId="submitterId"
+                        :is_internal=is_internal
+                    />
                 </div>
                 <div class="tab-pane fade" id="pills-vessels" role="tabpanel" aria-labelledby="pills-vessels-tab">
                     <div v-if="proposal">

--- a/mooringlicensing/frontend/mooringlicensing/src/components/internal/proposals/proposal.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/internal/proposals/proposal.vue
@@ -413,7 +413,6 @@ export default {
 
             // WLA
             if (this.$refs.waiting_list_application) {
-                payload.proposal.auto_approve = this.autoApprove;
                 if (this.$refs.waiting_list_application.$refs.vessels) {
                     payload.vessel = Object.assign({}, this.$refs.waiting_list_application.$refs.vessels.vessel);
                     payload.proposal.temporary_document_collection_id = this.$refs.waiting_list_application.$refs.vessels.temporary_document_collection_id;
@@ -427,7 +426,6 @@ export default {
                 }
             // AAA
             } else if (this.$refs.annual_admission_application) {
-                payload.proposal.auto_approve = this.autoApprove;
                 if (this.$refs.annual_admission_application.$refs.vessels) {
                     payload.vessel = Object.assign({}, this.$refs.annual_admission_application.$refs.vessels.vessel);
                     payload.proposal.temporary_document_collection_id = this.$refs.annual_admission_application.$refs.vessels.temporary_document_collection_id;
@@ -439,7 +437,6 @@ export default {
                 }
             // AUA
             } else if (this.$refs.authorised_user_application) {
-                payload.proposal.auto_approve = this.autoApprove;
                 if (this.$refs.authorised_user_application.$refs.vessels) {
                     payload.vessel = Object.assign({}, this.$refs.authorised_user_application.$refs.vessels.vessel);
                     payload.proposal.temporary_document_collection_id = this.$refs.authorised_user_application.$refs.vessels.temporary_document_collection_id;
@@ -466,7 +463,6 @@ export default {
                 }
             // MLA
             } else if (this.$refs.mooring_licence_application) {
-                payload.proposal.auto_approve = this.autoApprove;
                 if (this.$refs.mooring_licence_application.$refs.vessels) {
                     payload.vessel = Object.assign({}, this.$refs.mooring_licence_application.$refs.vessels.vessel);
                     payload.vessel.readonly = this.$refs.mooring_licence_application.$refs.vessels.readonly;

--- a/mooringlicensing/frontend/mooringlicensing/src/components/user/profile.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/user/profile.vue
@@ -367,42 +367,49 @@ export default {
             response = await Vue.http.get(api_endpoints.profile + '/' + this.proposalId)
             this.profile = Object.assign(response.body)
 
-            if (this.proposal.proposal_applicant) {
-                this.profile.residential_address_list.forEach(addr => {
-                    if (
-                        addr.line1 === this.proposal.proposal_applicant.residential_line1 &&
-                        addr.locality === this.proposal.proposal_applicant.residential_locality &&
-                        addr.state === this.proposal.proposal_applicant.residential_state &&
-                        addr.country === this.proposal.proposal_applicant.residential_country &&
-                        addr.postcode === this.proposal.proposal_applicant.residential_postcode
-                    ) {
-                        this.residential_address = Object.assign(addr)
-                    }
-                });
-            } else if (this.profile.residential_address_list.length == 1){
-                this.residential_address = Object.assign(this.profile.residential_address_list[0])
-            } else {
-                this.residential_address = "";
+            if (this.profile.residential_address_list !== undefined)
+            {
+                if (this.proposal.proposal_applicant) {
+                    this.profile.residential_address_list.forEach(addr => {
+                        if (
+                            addr.line1 === this.proposal.proposal_applicant.residential_line1 &&
+                            addr.locality === this.proposal.proposal_applicant.residential_locality &&
+                            addr.state === this.proposal.proposal_applicant.residential_state &&
+                            addr.country === this.proposal.proposal_applicant.residential_country &&
+                            addr.postcode === this.proposal.proposal_applicant.residential_postcode
+                        ) {
+                            this.residential_address = Object.assign(addr)
+                        }
+                    });
+                } else if (this.profile.residential_address_list.length == 1){
+                    this.residential_address = Object.assign(this.profile.residential_address_list[0])
+                } else {
+                    this.residential_address = "";
+                }
             }
-            if (this.proposal.proposal_applicant) {
-                this.profile.postal_address_list.forEach(addr => {
-                    if (
-                        addr.line1 === this.proposal.proposal_applicant.postal_line1 &&
-                        addr.locality === this.proposal.proposal_applicant.postal_locality &&
-                        addr.state === this.proposal.proposal_applicant.postal_state &&
-                        addr.country === this.proposal.proposal_applicant.postal_country &&
-                        addr.postcode === this.proposal.proposal_applicant.postal_postcode
-                    ) {
-                        this.postal_address = Object.assign(addr)
-                    }
-                });
-            } else if (this.profile.postal_address_list.length  == 1){
-                this.postal_address = Object.assign(this.profile.postal_address_list[0])
-            } else {
-                this.postal_address = "";
-            }
-            if (this.profile.legal_dob) {
-                this.profile.legal_dob = moment(this.profile.legal_dob).format('DD/MM/YYYY')
+
+            if (this.profile.postal_address_list !== undefined)
+            {
+                if (this.proposal.proposal_applicant) {
+                    this.profile.postal_address_list.forEach(addr => {
+                        if (
+                            addr.line1 === this.proposal.proposal_applicant.postal_line1 &&
+                            addr.locality === this.proposal.proposal_applicant.postal_locality &&
+                            addr.state === this.proposal.proposal_applicant.postal_state &&
+                            addr.country === this.proposal.proposal_applicant.postal_country &&
+                            addr.postcode === this.proposal.proposal_applicant.postal_postcode
+                        ) {
+                            this.postal_address = Object.assign(addr)
+                        }
+                    });
+                } else if (this.profile.postal_address_list.length  == 1){
+                    this.postal_address = Object.assign(this.profile.postal_address_list[0])
+                } else {
+                    this.postal_address = "";
+                }
+                if (this.profile.legal_dob) {
+                    this.profile.legal_dob = moment(this.profile.legal_dob).format('DD/MM/YYYY')
+                }
             }
         },
     },

--- a/mooringlicensing/frontend/mooringlicensing/src/components/user/profile.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/user/profile.vue
@@ -81,7 +81,7 @@
                         </div>
                     </form>
                   </div>
-                  <div v-else class="panel-body collapse in" :id="adBody">
+                  <div v-else-if="proposal.proposal_applicant" class="panel-body collapse in" :id="adBody">
                     <form class="form-horizontal">
                         <div class="form-group">
                             <label for="" class="col-sm-3 control-label" >
@@ -369,7 +369,7 @@ export default {
 
             if (this.profile.residential_address_list !== undefined)
             {
-                if (this.proposal.proposal_applicant) {
+                if (this.proposal.proposal_applicant !== null) {
                     this.profile.residential_address_list.forEach(addr => {
                         if (
                             addr.line1 === this.proposal.proposal_applicant.residential_line1 &&
@@ -383,14 +383,14 @@ export default {
                     });
                 } else if (this.profile.residential_address_list.length == 1){
                     this.residential_address = Object.assign(this.profile.residential_address_list[0])
-                } else {
-                    this.residential_address = "";
-                }
+                } 
+            } else {
+                this.residential_address = "";
             }
 
             if (this.profile.postal_address_list !== undefined)
             {
-                if (this.proposal.proposal_applicant) {
+                if (this.proposal.proposal_applicant !== null) {
                     this.profile.postal_address_list.forEach(addr => {
                         if (
                             addr.line1 === this.proposal.proposal_applicant.postal_line1 &&
@@ -404,12 +404,13 @@ export default {
                     });
                 } else if (this.profile.postal_address_list.length  == 1){
                     this.postal_address = Object.assign(this.profile.postal_address_list[0])
-                } else {
+                } 
+            }   else {
                     this.postal_address = "";
-                }
-                if (this.profile.legal_dob) {
-                    this.profile.legal_dob = moment(this.profile.legal_dob).format('DD/MM/YYYY')
-                }
+            }
+
+            if (this.profile.legal_dob !== null && this.profile.legal_dob !== "") {
+                this.profile.legal_dob = moment(this.profile.legal_dob).format('DD/MM/YYYY')
             }
         },
     },

--- a/mooringlicensing/helpers.py
+++ b/mooringlicensing/helpers.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-# from ledger.accounts.models import EmailUser
 from django.conf import settings
 from django.core.cache import cache
 

--- a/mooringlicensing/helpers.py
+++ b/mooringlicensing/helpers.py
@@ -81,11 +81,12 @@ def is_internal(request):
 def is_authorised_to_modify(request, instance):
     authorised = True
 
-    if is_customer(request):
-        # the status of the application must be DRAFT for customer to modify
-        authorised &= instance.processing_status in [Proposal.PROCESSING_STATUS_DRAFT, Proposal.PROCESSING_STATUS_AWAITING_DOCUMENTS, Proposal.PROCESSING_STATUS_PRINTING_STICKER,]
-        # the applicant and submitter must be the same
-        authorised &= request.user.email == instance.applicant_email
+    #if is_customer(request):
+    # the status of the application must be DRAFT for customer to modify
+    #TODO investigate why the (now) commented out statuses were in the below list (needed or mistake?)
+    authorised &= instance.processing_status in [Proposal.PROCESSING_STATUS_DRAFT] #, Proposal.PROCESSING_STATUS_AWAITING_DOCUMENTS, Proposal.PROCESSING_STATUS_PRINTING_STICKER,]
+    # the applicant and submitter must be the same
+    authorised &= request.user.email == instance.applicant_email
 
     if not authorised:
         logger.warning(f'User: [{request.user}] is not authorised to modify this proposal: [{instance}].  Raise an error.')

--- a/mooringlicensing/management/commands/approval_renewal_notices.py
+++ b/mooringlicensing/management/commands/approval_renewal_notices.py
@@ -11,8 +11,6 @@ from mooringlicensing.components.approvals.models import (
     MooringLicence,
     DcvPermit, ApprovalUserAction,
 )
-# from ledger.accounts.models import EmailUser
-from ledger_api_client.ledger_models import EmailUserRO
 from datetime import timedelta
 from mooringlicensing.components.proposals.email import send_approval_renewal_email_notification
 
@@ -91,13 +89,6 @@ class Command(BaseCommand):
                 errors.append(err_msg)
 
     def handle(self, *args, **options):
-        try:
-            # user = EmailUser.objects.get(email=settings.CRON_EMAIL)
-            user = EmailUserRO.objects.get(email=settings.CRON_EMAIL)
-        except:
-            # user = EmailUser.objects.create(email=settings.CRON_EMAIL, password='')
-            user = EmailUserRO.objects.create(email=settings.CRON_EMAIL, password='')
-
         updates, errors = [], []
 
         self.perform_per_type(CODE_DAYS_FOR_RENEWAL_WLA, WaitingListAllocation, updates, errors)

--- a/mooringlicensing/management/commands/expire_mooring_licence_application_due_to_no_documents.py
+++ b/mooringlicensing/management/commands/expire_mooring_licence_application_due_to_no_documents.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-# from ledger.accounts.models import EmailUser
 from django.utils import timezone
 
 from django.core.management.base import BaseCommand

--- a/mooringlicensing/management/commands/expire_mooring_licence_application_due_to_no_submit.py
+++ b/mooringlicensing/management/commands/expire_mooring_licence_application_due_to_no_submit.py
@@ -1,6 +1,4 @@
 from datetime import timedelta
-# from ledger.accounts.models import EmailUser
-from ledger_api_client.ledger_models import EmailUserRO
 
 from django.utils import timezone
 from django.core.management.base import BaseCommand
@@ -25,13 +23,6 @@ class Command(BaseCommand):
     help = 'expire mooring site licence application if not submitted within configurable number of days after being invited to apply for a mooring site licence and send email to inform waiting list allocation holder'
 
     def handle(self, *args, **options):
-        try:
-            # user = EmailUser.objects.get(email=settings.CRON_EMAIL)
-            user = EmailUserRO.objects.get(email=settings.CRON_EMAIL)
-        except:
-            # user = EmailUser.objects.create(email=settings.CRON_EMAIL, password='')
-            user = EmailUserRO.objects.create(email=settings.CRON_EMAIL, password='')
-
         errors = []
         updates = []
         today = timezone.localtime(timezone.now()).date()

--- a/mooringlicensing/management/commands/send_compliance_reminder.py
+++ b/mooringlicensing/management/commands/send_compliance_reminder.py
@@ -16,10 +16,6 @@ class Command(BaseCommand):
     help = 'Send notification emails for compliances which has past due dates, and also reminder notification emails for those that are within the daterange prior to due_date (eg. within 14 days of due date)'
 
     def handle(self, *args, **options):
-        try:
-            user = EmailUser.objects.get(email=settings.CRON_EMAIL)
-        except:
-            user = EmailUser.objects.create(email=settings.CRON_EMAIL, password='') #TODO: is this allowed?
 
         errors = []
         updates = []
@@ -28,7 +24,7 @@ class Command(BaseCommand):
 
         for c in Compliance.objects.filter(processing_status=Compliance.PROCESSING_STATUS_DUE):
             try:
-                c.send_reminder(user)
+                c.send_reminder()
                 c.save()
                 updates.append(c.lodgement_number)
             except Exception as e:

--- a/mooringlicensing/management/commands/send_compliance_reminder.py
+++ b/mooringlicensing/management/commands/send_compliance_reminder.py
@@ -2,7 +2,7 @@ from django.core.management.base import BaseCommand
 from django.utils import timezone
 from django.conf import settings
 from mooringlicensing.components.compliances.models import Compliance
-from ledger.accounts.models import EmailUser
+from ledger_api_client.models import EmailUser
 
 import logging
 
@@ -19,7 +19,7 @@ class Command(BaseCommand):
         try:
             user = EmailUser.objects.get(email=settings.CRON_EMAIL)
         except:
-            user = EmailUser.objects.create(email=settings.CRON_EMAIL, password='')
+            user = EmailUser.objects.create(email=settings.CRON_EMAIL, password='') #TODO: is this allowed?
 
         errors = []
         updates = []

--- a/mooringlicensing/management/commands/send_endorser_reminder.py
+++ b/mooringlicensing/management/commands/send_endorser_reminder.py
@@ -5,8 +5,6 @@ from django.utils import timezone
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Q
-# from ledger.accounts.models import EmailUser
-from ledger_api_client.ledger_models import EmailUserRO
 
 import logging
 
@@ -24,12 +22,6 @@ class Command(BaseCommand):
     help = 'Send email to authorised user application endorser if application is not endorsed or declined within configurable number of days'
 
     def handle(self, *args, **options):
-        try:
-            # user = EmailUser.objects.get(email=settings.CRON_EMAIL)
-            user = EmailUserRO.objects.get(email=settings.CRON_EMAIL)
-        except:
-            # user = EmailUser.objects.create(email=settings.CRON_EMAIL, password='')
-            user = EmailUserRO.objects.create(email=settings.CRON_EMAIL, password='')
 
         errors = []
         updates = []

--- a/mooringlicensing/management/commands/send_mooring_licence_application_submit_due_reminder.py
+++ b/mooringlicensing/management/commands/send_mooring_licence_application_submit_due_reminder.py
@@ -5,9 +5,6 @@ from django.utils import timezone
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Q
-# from ledger.accounts.models import EmailUser
-from ledger_api_client.ledger_models import EmailUserRO
-
 import logging
 
 from mooringlicensing.components.proposals.email import send_invitee_reminder_email
@@ -24,12 +21,6 @@ class Command(BaseCommand):
     help = 'Send email to waiting list allocation holder invited to apply for a mooring licence configurable number of days before end of configurable period in which the mooring licence application needs to be submitted'
 
     def handle(self, *args, **options):
-        try:
-            # user = EmailUser.objects.get(email=settings.CRON_EMAIL)
-            user = EmailUserRO.objects.get(email=settings.CRON_EMAIL)
-        except:
-            # user = EmailUser.objects.create(email=settings.CRON_EMAIL, password='')
-            user = EmailUserRO.objects.create(email=settings.CRON_EMAIL, password='')
 
         errors = []
         updates = []

--- a/mooringlicensing/management/commands/update_approval_status.py
+++ b/mooringlicensing/management/commands/update_approval_status.py
@@ -8,8 +8,7 @@ from mooringlicensing.components.approvals.models import (
     ApprovalUserAction, WaitingListAllocation,
 )
 from mooringlicensing.components.proposals.models import ProposalUserAction
-# from ledger.accounts.models import EmailUser
-from ledger_api_client.ledger_models import EmailUserRO
+from ledger_api_client.models import EmailUser
 import datetime
 from mooringlicensing.components.approvals.email import (
     send_approval_cancel_email_notification,
@@ -30,11 +29,9 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         try:
-            # user = EmailUser.objects.get(email=settings.CRON_EMAIL)
-            user = EmailUserRO.objects.get(email=settings.CRON_EMAIL)
+            user = EmailUser.objects.get(email=settings.CRON_EMAIL)
         except:
-            # user = EmailUser.objects.create(email=settings.CRON_EMAIL, password = '')
-            user = EmailUserRO.objects.create(email=settings.CRON_EMAIL, password = '')
+            user = EmailUser.objects.create(email=settings.CRON_EMAIL, password = '') #TODO: is this allowed?
 
         errors = []
         updates = []

--- a/mooringlicensing/management/commands/update_approval_status.py
+++ b/mooringlicensing/management/commands/update_approval_status.py
@@ -28,11 +28,6 @@ class Command(BaseCommand):
     help = 'Change the status of Approvals to Expired / Surrender/ Cancelled/ Suspended.'
 
     def handle(self, *args, **options):
-        try:
-            user = EmailUser.objects.get(email=settings.CRON_EMAIL)
-        except:
-            user = EmailUser.objects.create(email=settings.CRON_EMAIL, password = '') #TODO: is this allowed?
-
         errors = []
         updates = []
         today = timezone.localtime(timezone.now()).date()
@@ -46,7 +41,7 @@ class Command(BaseCommand):
         approvals = Approval.objects.filter(queries)
         for approval in approvals:
             try:
-                approval.expire_approval(user)
+                approval.expire_approval()
                 # a.save()  # Saved in the above function...?
                 logger.info('Updated Approval {} status to {}'.format(approval.id, approval.status))
                 updates.append(approval.lodgement_number)

--- a/mooringlicensing/management/commands/update_compliance_status.py
+++ b/mooringlicensing/management/commands/update_compliance_status.py
@@ -27,11 +27,6 @@ class Command(BaseCommand):
         days_setting = NumberOfDaysSetting.get_setting_by_date(days_type, today)
         compare_date = today + datetime.timedelta(days=days_setting.number_of_days)
 
-        try:
-            user = EmailUser.objects.get(email=settings.CRON_EMAIL)
-        except:
-            user = EmailUser.objects.create(email=settings.CRON_EMAIL, password='') #TODO: is this allowed?
-
         errors = []
         updates = []
         logger.info('Running command {}'.format(__name__))
@@ -61,7 +56,7 @@ class Command(BaseCommand):
                 c.processing_status = Compliance.PROCESSING_STATUS_DUE
                 c.customer_status = Compliance.CUSTOMER_STATUS_DUE
                 c.save()
-                ComplianceUserAction.log_action(c, ComplianceUserAction.ACTION_STATUS_CHANGE.format(c.id), user)
+                ComplianceUserAction.log_action(c, ComplianceUserAction.ACTION_STATUS_CHANGE.format(c.id))
                 logger.info('updated Compliance {} status to {}'.format(c.id, c.processing_status))
                 updates.append(c.lodgement_number)
             except Exception as e:
@@ -80,7 +75,7 @@ class Command(BaseCommand):
                 c.processing_status = Compliance.PROCESSING_STATUS_OVERDUE
                 c.customer_status = Compliance.CUSTOMER_STATUS_OVERDUE
                 c.save()
-                ComplianceUserAction.log_action(c, ComplianceUserAction.ACTION_STATUS_CHANGE.format(c.id), user)
+                ComplianceUserAction.log_action(c, ComplianceUserAction.ACTION_STATUS_CHANGE.format(c.id), None)
                 logger.info('updated Compliance {} status to {}'.format(c.id, c.processing_status))
                 updates.append(c.lodgement_number)
             except Exception as e:

--- a/mooringlicensing/management/commands/update_compliance_status.py
+++ b/mooringlicensing/management/commands/update_compliance_status.py
@@ -2,7 +2,7 @@ from django.core.management.base import BaseCommand
 from django.db.models import Q
 from django.utils import timezone
 from django.conf import settings
-from ledger.accounts.models import EmailUser
+from ledger_api_client.models import EmailUser
 
 from mooringlicensing.components.approvals.models import Approval
 from mooringlicensing.components.compliances.models import Compliance, ComplianceUserAction
@@ -30,7 +30,7 @@ class Command(BaseCommand):
         try:
             user = EmailUser.objects.get(email=settings.CRON_EMAIL)
         except:
-            user = EmailUser.objects.create(email=settings.CRON_EMAIL, password='')
+            user = EmailUser.objects.create(email=settings.CRON_EMAIL, password='') #TODO: is this allowed?
 
         errors = []
         updates = []

--- a/mooringlicensing/mooring_booking_utils.py
+++ b/mooringlicensing/mooring_booking_utils.py
@@ -1459,7 +1459,6 @@ def booking_success(basket, booking, context_processor):
             #Calculate Admissions and create object
             if booking.admission_payment:
                  ad_booking = AdmissionsBooking.objects.get(pk=booking.admission_payment.pk)
-                 #if request.user.__class__.__name__ == 'EmailUser':
                  ad_booking.created_by = booking.created_by
                  ad_booking.booking_type=1
                  print("MLINE 8.02", datetime.now().strftime("%d/%m/%Y %H:%M:%S"))
@@ -1630,8 +1629,6 @@ def booking_admission_success(basket, booking, context_processor):
              logger.info('{} finished temporary booking {}, creating new AdmissionBookingInvoice with reference {}'.format('User {} with id {}'.format(booking.customer.get_full_name(),booking.customer.id) if booking.customer else 'An anonymous user',booking.id, invoice_ref))
              # FIXME: replace with server side notify_url callback
              admissionsInvoice = AdmissionsBookingInvoice.objects.get_or_create(admissions_booking=booking, invoice_reference=invoice_ref)
-             #if request.user.__class__.__name__ == 'EmailUser':
-             #    booking.created_by = request.user
 
              # set booking to be permanent fixture
              booking.booking_type = 1  # internet booking

--- a/mooringlicensing/urls.py
+++ b/mooringlicensing/urls.py
@@ -191,28 +191,7 @@ urlpatterns = [
     re_path(r'^api/check_oracle_code$', payments_api.CheckOracleCodeView.as_view(), name='check_oracle_code'),
     re_path(r'^api/refund_oracle$', payments_api.RefundOracleView.as_view(), name='refund_oracle'),
 
-    #TODO: I have opted to use this single view function as it simpler to run auth and maintain
     re_path(r'^private-media/', views.getPrivateFile, name='view_private_file'),
-
-    #re_path(r'^' + PRIVATE_MEDIA_DIR_NAME + '/proposal/(?P<proposal_id>\d+)/vessel_registration_documents/(?P<filename>.+)$', proposal_views.VesselRegistrationDocumentView.as_view(), name='serve_vessel_registration_documents'),
-    #re_path(r'^' + PRIVATE_MEDIA_DIR_NAME + '/proposal/(?P<proposal_id>\d+)/hull_identification_number_documents/(?P<filename>.+)$', proposal_views.HullIdentificationNumberDocumentView.as_view(), name='serve_hull_identification_number_documents'),
-    #re_path(r'^' + PRIVATE_MEDIA_DIR_NAME + '/proposal/(?P<proposal_id>\d+)/electoral_roll_documents/(?P<filename>.+)$', proposal_views.ElectoralRollDocumentView.as_view(), name='serve_electoral_roll_documents'),
-    #re_path(r'^' + PRIVATE_MEDIA_DIR_NAME + '/proposal/(?P<proposal_id>\d+)/insurance_certificate_documents/(?P<filename>.+)$', proposal_views.InsuranceCertificateDocumentView.as_view(), name='serve_insurance_certificate_documents'),
-    #re_path(r'^' + PRIVATE_MEDIA_DIR_NAME + '/proposal/(?P<proposal_id>\d+)/written_proof_documents/(?P<filename>.+)$', proposal_views.WrittenProofDocumentView.as_view(), name='serve_written_proof_documents'),
-    #re_path(r'^' + PRIVATE_MEDIA_DIR_NAME + '/proposal/(?P<proposal_id>\d+)/signed_licence_agreement_documents/(?P<filename>.+)$', proposal_views.SignedLicenceAgreementDocumentView.as_view(), name='serve_signed_licence_agreement_documents'),
-    #re_path(r'^' + PRIVATE_MEDIA_DIR_NAME + '/proposal/(?P<proposal_id>\d+)/proof_of_identity_documents/(?P<filename>.+)$', proposal_views.ProofOfIdentityDocumentView.as_view(), name='serve_proof_of_identity_documents'),
-    #re_path(r'^' + PRIVATE_MEDIA_DIR_NAME + '/approval/(?P<approval_id>\d+)/waiting_list_offer_documents/(?P<filename>.+)$', proposal_views.WaitingListOfferDocumentView.as_view(), name='serve_waiting_list_offer_documents'),
-#
-    #re_path(r'^' + PRIVATE_MEDIA_DIR_NAME + '/proposal/(?P<proposal_id>\d+)/approval_documents/(?P<filename>.+)$', proposal_views.ApprovalDocumentView.as_view(), name='serve_approval_documents'),
-    #re_path(r'^' + PRIVATE_MEDIA_DIR_NAME + '/proposal/(?P<proposal_id>\d+)/authorised_user_summary_documents/(?P<filename>.+)$', proposal_views.AuthorisedUserSummaryDocumentView.as_view(), name='serve_authorised_user_summary_documents'),
-    #re_path(r'^' + PRIVATE_MEDIA_DIR_NAME + '/proposal/(?P<proposal_id>\d+)/renewal_documents/(?P<filename>.+)$', proposal_views.RenewalDocumentView.as_view(), name='serve_renewal_documents'),
-    #re_path(r'^' + PRIVATE_MEDIA_DIR_NAME + '/proposal/(?P<proposal_id>\d+)/approvals/communications/(?P<filename>.+)$', proposal_views.ApprovalLogDocumentView.as_view(), name='serve_approval_log_documents'),
-    #re_path(r'^' + PRIVATE_MEDIA_DIR_NAME + '/dcv_admission/(?P<dcv_admission_id>\d+)/dcv_admission_documents/(?P<filename>.+)$', proposal_views.DcvAdmissionDocumentView.as_view(), name='serve_dcv_admission_documents'),
-    #re_path(r'^' + PRIVATE_MEDIA_DIR_NAME + '/dcv_permit/(?P<dcv_permit_id>\d+)/dcv_permit_documents/(?P<filename>.+)$', proposal_views.DcvPermitDocumentView.as_view(), name='serve_dcv_permit_documents'),
-
-    #TODO remove
-    # Intercept the request to update the account details before reaching the ledger_api_client
-    # re_path(r'^ledger-ui/api/update-account-details/(?P<user_id>[0-9]+)/', update_personal_details, name='update-account-details'),
 
 ] + ledger_patterns #+ media_serv_patterns
 

--- a/mooringlicensing/urls.py
+++ b/mooringlicensing/urls.py
@@ -9,7 +9,6 @@ import mooringlicensing
 # import mooringlicensing.components.approvals.api
 from mooringlicensing import views
 from mooringlicensing.components.approvals.views import DcvAdmissionFormView
-from mooringlicensing.components.main.utils import update_personal_details
 from mooringlicensing.components.payments_ml.views import ApplicationFeeView, ApplicationFeeSuccessView, InvoicePDFView, \
     DcvPermitFeeView, DcvPermitFeeSuccessView, DcvPermitPDFView, ConfirmationView, DcvAdmissionFeeView, \
     DcvAdmissionFeeSuccessView, DcvAdmissionPDFView, ApplicationFeeExistingView, StickerReplacementFeeView, \


### PR DESCRIPTION
- Removed unused/replaced EmailUser references - EmailUser still used for email, user assignment, and auth
- Dashboard search now uses SystemUser values over EmailUser values
- Removed/Replaced instances of EmailUser.objects.create()
- Assessors and Approvers can now edit applications in their respective processing states (assessors can also edit drafts)