### PR TITLE
Server-side auto-approve, Sticker Expiry

### DIFF
--- a/mooringlicensing/components/payments_ml/views.py
+++ b/mooringlicensing/components/payments_ml/views.py
@@ -399,7 +399,7 @@ class ApplicationFeeView(TemplateView):
             #check for auto approval
             auto_approved = is_authorised_to_pay_auto_approved(request,proposal)
             if not auto_approved:
-                is_authorised_to_modify(request, proposal) #TODO or is being paid after being auto approved...
+                is_authorised_to_modify(request, proposal)
             post_data_pre = request.POST
             post_data = {}
             for i in post_data_pre:
@@ -409,7 +409,7 @@ class ApplicationFeeView(TemplateView):
                     continue
 
             setattr(request,"data",post_data)
-            save_proponent_data(proposal, request, "submit")
+            save_proponent_data(proposal, request, "submit", auto_approved)
 
             proposal = self.get_object()
             is_applicant_address_set(proposal)

--- a/mooringlicensing/components/payments_ml/views.py
+++ b/mooringlicensing/components/payments_ml/views.py
@@ -50,7 +50,7 @@ from ledger_api_client.order import Order
 # from ledger.order.models import Order
 # >>>>>>> main
 
-from mooringlicensing.helpers import is_authorised_to_modify, is_applicant_address_set
+from mooringlicensing.helpers import is_authorised_to_modify, is_applicant_address_set, is_authorised_to_pay_auto_approved
 from mooringlicensing import settings
 from mooringlicensing.components.approvals.models import DcvPermit, DcvAdmission, Approval, StickerActionDetail, Sticker
 from mooringlicensing.components.payments_ml.email import send_application_submit_confirmation_email
@@ -396,7 +396,10 @@ class ApplicationFeeView(TemplateView):
         proposal = self.get_object()
 
         try:
-            is_authorised_to_modify(request, proposal)
+            #check for auto approval
+            auto_approved = is_authorised_to_pay_auto_approved(request,proposal)
+            if not auto_approved:
+                is_authorised_to_modify(request, proposal) #TODO or is being paid after being auto approved...
             post_data_pre = request.POST
             post_data = {}
             for i in post_data_pre:

--- a/mooringlicensing/components/proposals/api.py
+++ b/mooringlicensing/components/proposals/api.py
@@ -2290,7 +2290,7 @@ class VesselViewSet(viewsets.ModelViewSet):
         elif is_customer(self.request):
             owner = Owner.objects.filter(emailuser=user.id)
             if owner:
-                queryset = owner[0].vessels.all()
+                queryset = owner.first().vessels.distinct()
         return queryset
 
     @detail_route(methods=['POST',], detail=True)

--- a/mooringlicensing/components/proposals/api.py
+++ b/mooringlicensing/components/proposals/api.py
@@ -1739,7 +1739,9 @@ class ProposalViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
             instance = self.get_object()
             is_authorised_to_modify(request, instance)
             save_proponent_data(instance,request,self.action)
-            return redirect(reverse('external'))
+            instance = self.get_object()
+            serializer = self.serializer_class(instance, context={'request':request})
+            return Response(serializer.data)
         
     @detail_route(methods=['post'], detail=True)
     @renderer_classes((JSONRenderer,))

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -4581,8 +4581,9 @@ class Vessel(RevisionedMixin):
         # 1. other application in status other than issued, declined or discarded where the applicant is another owner than this applicant
         proposals_filter = Q()  # This is condition for the proposal to be blocking proposal.
         proposals_filter &= Q(vessel_ownership__vessel=self)  # Blocking proposal is for the same vessel
-        proposals_filter &= ~Q(processing_status__in=[  # Blocking proposal's status is not the statuses listed
+        proposals_filter &= ~Q(processing_status__in=[  # Blocking proposal's status is not in the statuses listed
             Proposal.PROCESSING_STATUS_APPROVED,
+            Proposal.PROCESSING_STATUS_PRINTING_STICKER, #it is possible for an approval to expire before the sticker has printed
             Proposal.PROCESSING_STATUS_DECLINED,
             Proposal.PROCESSING_STATUS_EXPIRED,
             Proposal.PROCESSING_STATUS_DISCARDED,

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -2671,9 +2671,10 @@ class WaitingListApplication(Proposal):
                 self.vessel_ownership_changed()
                 ):
                 self.auto_approve = False        
-
-            self.auto_approve = True
-            self.save()
+                self.save()
+            else:
+                self.auto_approve = True
+                self.save()
         
 
     def validate_against_existing_proposals_and_approvals(self):

--- a/mooringlicensing/components/proposals/serializers.py
+++ b/mooringlicensing/components/proposals/serializers.py
@@ -231,8 +231,9 @@ class BaseProposalSerializer(serializers.ModelSerializer):
                 'proposal_applicant',
                 'uuid',
                 'amendment_requests',
+                'auto_approve',
                 )
-        read_only_fields=('documents',)
+        read_only_fields=('documents','auto_approve')
 
     def get_amendment_requests(self, obj):
         data = None
@@ -660,7 +661,6 @@ class SaveWaitingListApplicationSerializer(serializers.ModelSerializer):
                 'silent_elector',
                 'temporary_document_collection_id',
                 'keep_existing_vessel',
-                'auto_approve', #TODO: if auto approve is supposed to be strictly based on other values we should NOT let the client set it
                 )
         read_only_fields=('id',)
 
@@ -699,7 +699,6 @@ class SaveAnnualAdmissionApplicationSerializer(serializers.ModelSerializer):
                 'insurance_choice',
                 'temporary_document_collection_id',
                 'keep_existing_vessel',
-                'auto_approve',
                 )
         read_only_fields=('id',)
 
@@ -737,7 +736,6 @@ class SaveMooringLicenceApplicationSerializer(serializers.ModelSerializer):
                 'processing_status',
                 'temporary_document_collection_id',
                 'keep_existing_vessel',
-                'auto_approve',
                 )
         read_only_fields=('id',)
 
@@ -801,7 +799,6 @@ class SaveAuthorisedUserApplicationSerializer(serializers.ModelSerializer):
                 'temporary_document_collection_id',
                 'keep_existing_mooring',
                 'keep_existing_vessel',
-                'auto_approve',
                 )
         read_only_fields=('id',)
 

--- a/mooringlicensing/components/proposals/utils.py
+++ b/mooringlicensing/components/proposals/utils.py
@@ -1195,3 +1195,37 @@ def get_file_content_http_response(file_path):
             response = HttpResponse(f, content_type=mime_type_guess[0])
         response['Content-Disposition'] = 'inline;filename={}'.format(f_name)
         return response
+    
+def get_max_vessel_length_for_main_component(proposal):
+
+    max_vessel_length = (0, True)  # (length, include_length)
+    get_out_of_loop = False
+    #TODO improve this.
+    while True:
+        for application_fee in proposal.application_fees.all():
+            for fee_item_application_fee in application_fee.feeitemapplicationfee_set.all():
+                if fee_item_application_fee.application_fee.proposal.application_type == fee_item_application_fee.fee_item.fee_constructor.application_type:
+                    logger.info(f'FeeItemApplicationFee: [{fee_item_application_fee}] is the main component of the proposal: [{proposal}]')
+                    length_tuple = fee_item_application_fee.get_max_allowed_length()
+                    if max_vessel_length[0] < length_tuple[0] or (max_vessel_length[0] == length_tuple[0] and length_tuple[1] == True):
+                        max_vessel_length = length_tuple
+                else:
+                    logger.info(f'FeeItemApplicationFee: [{fee_item_application_fee}] is not the main component of the proposal: [{proposal}]')
+
+        if get_out_of_loop:
+            break
+
+        # Retrieve the previous application
+        proposal = proposal.previous_application
+
+        if not proposal:
+            # No previous application exists.  Get out of the loop
+            break
+        else:
+            # Previous application exists
+            if proposal.proposal_type.code in [PROPOSAL_TYPE_NEW, PROPOSAL_TYPE_RENEWAL,]:
+                # Previous application is 'new'/'renewal'
+                # In this case, we don't want to go back any further once this proposal is processed in the next loop.  Therefore we set the flat to True
+                get_out_of_loop = True
+
+    return max_vessel_length

--- a/mooringlicensing/components/proposals/utils.py
+++ b/mooringlicensing/components/proposals/utils.py
@@ -363,7 +363,7 @@ def save_proponent_data(instance, request, action):
         elif type(instance.child_obj) == AuthorisedUserApplication:
             save_proponent_data_aua(instance, request, action)
         elif type(instance.child_obj) == MooringLicenceApplication:
-            save_proponent_data_mla(instance, request, action)
+            save_proponent_data_mla(instance, request, action) 
 
         if instance.proposal_applicant and instance.proposal_applicant.email_user_id == request.user.id:
             # Save request.user details in a JSONField not to overwrite the details of it.
@@ -376,6 +376,8 @@ def save_proponent_data(instance, request, action):
             except Exception as e:
                 print(e)
                 raise serializers.ValidationError("error")
+            
+        instance.child_obj.set_auto_approve(request)
     else:
         raise serializers.ValidationError("user not authorised to update applicant details")
 

--- a/mooringlicensing/components/proposals/utils.py
+++ b/mooringlicensing/components/proposals/utils.py
@@ -345,12 +345,12 @@ class SpecialFieldsSearch(object):
             item_data[item['name']] = item_data_list
         return item_data
 
-def save_proponent_data(instance, request, action):
+def save_proponent_data(instance, request, action, being_auto_approved=False):
 
     if (
         (instance.proposal_applicant and 
          instance.proposal_applicant.email_user_id == request.user.id and 
-         instance.processing_status == Proposal.PROCESSING_STATUS_DRAFT)
+         (instance.processing_status == Proposal.PROCESSING_STATUS_DRAFT) or being_auto_approved)
         or instance.has_assessor_mode(request.user)
         or instance.has_approver_mode(request.user)
     ):

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/current_vessels.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/current_vessels.vue
@@ -165,29 +165,7 @@ from '@/utils/hooks'
                     this.keep_current_vessel = this.proposal.keep_existing_vessel
                     this.resetCurrentVessel()
                 }
-            } else {
-                // Shouldn't reach here.  There should be a proposal.
-            }
-
-            // if (this.proposal && this.proposal.proposal_type.code == 'new' && this.proposal.processing_status != 'Draft'){
-            //     console.log('mounted1')
-            //     this.keep_current_vessel = true
-            //     this.resetCurrentVessel()
-            // } else if (this.proposal && !this.proposal.keep_existing_vessel) {
-            //     console.log('mounted2')
-            //     this.keep_current_vessel = false
-            //     this.resetCurrentVessel()
-            // } else if (!this.vesselExists){
-            //     console.log('mounted3')
-            //     this.keep_current_vessel = false
-            //     this.resetCurrentVessel()
-            // } else if (this.proposal && this.proposal.proposal_type.code == 'swap_moorings'){
-            //     // When swap moorings, always keep the current vessel
-            //     this.keep_current_vessel = true
-            //     this.resetCurrentVessel()
-            // } else {
-            //     console.log('mounted4')
-            // }
+            } 
         },
         created: function() {
         },

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/mooring.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/mooring.vue
@@ -65,7 +65,7 @@ from '@/utils/hooks'
             mooringPreferenceChanged: async function() {
                 console.log("mooringPrefChanged");
                 let preferenceChanged = false;
-                if (this.proposal.previous_application_preferred_bay !== this.selectedMooring) {
+                if (this.proposal.previous_application_preferred_bay_id !== this.selectedMooring) {
                     preferenceChanged = true;
                 }
                 this.$emit("mooringPreferenceChanged", preferenceChanged);

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/mooring_authorisation.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/mooring_authorisation.vue
@@ -126,7 +126,7 @@ import draggable from 'vuedraggable';
                 if (this.proposal.bay_preferences_numbered) {
                     let newArray = [];
                     for (let n of this.proposal.bay_preferences_numbered) {
-                        const found = response.body.find(el => el.id === n);
+                        const found = response.body.results.find(el => el.id === n);
                         newArray.push(found);
                     }
                     // read ordered array into Vue array

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/table_approvals.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/table_approvals.vue
@@ -554,7 +554,7 @@ export default {
             return {
                         data: "id",
                         orderable: false,
-                        searchable: true,
+                        searchable: false,
                         visible: true,
                         'render': function(row, type, full){
                             return full.holder;

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/table_stickers.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/table_stickers.vue
@@ -161,7 +161,7 @@ export default {
             return {
                 data: "approval",
                 orderable: false,
-                searchable: true,
+                searchable: false,
                 visible: true,
                 'render': function(row, type, full){
                     if (full.approval){

--- a/mooringlicensing/frontend/mooringlicensing/src/components/external/proposal.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/external/proposal.vue
@@ -38,7 +38,6 @@
                 ref="waiting_list_application"
                 :showElectoralRoll="showElectoralRoll"
                 :readonly="readonly"
-                @updateAutoApprove="updateAutoApprove"
                 @updateSubmitText="updateSubmitText"
                 @vesselChanged="updateVesselChanged"
                 @mooringPreferenceChanged="updateMooringPreference"
@@ -54,7 +53,6 @@
                 ref="annual_admission_application"
                 :showElectoralRoll="showElectoralRoll"
                 :readonly="readonly"
-                @updateAutoApprove="updateAutoApprove"
                 @updateSubmitText="updateSubmitText"
                 @vesselChanged="updateVesselChanged"
                 @updateVesselOwnershipChanged="updateVesselOwnershipChanged"
@@ -68,7 +66,6 @@
                 ref="authorised_user_application"
                 :readonly="readonly"
                 @updateSubmitText="updateSubmitText"
-                @updateAutoApprove="updateAutoApprove"
                 @vesselChanged="updateVesselChanged"
                 @changeMooring="updateMooringAuth"
                 @updateVesselOwnershipChanged="updateVesselOwnershipChanged"
@@ -83,7 +80,6 @@
                 :showElectoralRoll="showElectoralRoll"
                 :readonly="readonly"
                 @updateSubmitText="updateSubmitText"
-                @updateAutoApprove="updateAutoApprove"
                 @vesselChanged="updateVesselChanged"
                 @updateVesselOwnershipChanged="updateVesselOwnershipChanged"
                 @noVessel="noVessel"
@@ -187,7 +183,6 @@ export default {
       mooringPreferenceChanged: false,
       vesselOwnershipChanged: false,
       submitText: "Submit",
-      autoApprove: false,
       missingVessel: false,
       // add_vessel: false,
       profile_original: {},
@@ -395,11 +390,6 @@ export default {
     noVessel: function(noVessel) {
         this.missingVessel = noVessel;
     },
-    updateAutoApprove: function(approve) {
-        this.autoApprove = approve;
-        console.log('%cin updateAutoApprove', 'color: #990000')
-        console.log(this.autoApprove)
-    },
     updateMooringAuth: function(changed) {
         this.mooringOptionsChanged = changed;
         //console.log("updateMooringAuth");
@@ -464,6 +454,9 @@ export default {
                     'success'
                 );
             };
+            if (res.body.auto_approve !== undefined) {
+                vm.proposal.auto_approve = res.body.auto_approve;
+            }
             vm.savingProposal=false;
             this.submitRes = true;
             return res;
@@ -507,8 +500,7 @@ export default {
                 if (this.submitRes) {
                     let payload = this.buildPayload();
                     payload.csrfmiddlewaretoken = this.csrf_token;
-                    console.log("autoApprove",this.autoApprove); //TODO get this from the the submitRes instead?
-                    if (this.autoApprove) {
+                    if (this.proposal.auto_approve) {
                         this.post_and_redirect(this.application_fee_url, payload);
                     } else if (['wla', 'aaa'].includes(this.proposal.application_type_code)) {
                         this.post_and_redirect(this.application_fee_url, payload);

--- a/mooringlicensing/frontend/mooringlicensing/src/components/external/proposal.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/external/proposal.vue
@@ -507,6 +507,7 @@ export default {
                 if (this.submitRes) {
                     let payload = this.buildPayload();
                     payload.csrfmiddlewaretoken = this.csrf_token;
+                    console.log("autoApprove",this.autoApprove); //TODO get this from the the submitRes instead?
                     if (this.autoApprove) {
                         this.post_and_redirect(this.application_fee_url, payload);
                     } else if (['wla', 'aaa'].includes(this.proposal.application_type_code)) {

--- a/mooringlicensing/frontend/mooringlicensing/src/components/form_aua.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/form_aua.vue
@@ -287,27 +287,6 @@
             vesselChanged: async function(vesselChanged) {
                 await this.$emit("vesselChanged", vesselChanged);
             },
-            /*
-            updateVesselLength: function(length) {
-                let higherCategory = false;
-                if (this.is_external && this.proposal) {
-                    if (!this.proposal.previous_application_id) {
-                        // new application
-                        //higherCategory = true;
-                        //pass
-                    } else if (this.proposal.max_vessel_length_with_no_payment &&
-                        this.proposal.max_vessel_length_with_no_payment <= length) {
-                        // vessel length is in higher category
-                        higherCategory = true;
-                    }
-                }
-                console.log(higherCategory);
-                if (higherCategory) {
-                    this.showPaymentTab = true;
-                    this.$emit("updateSubmitText", "Pay / Submit");
-                }
-            },
-            */
             updateVesselLength: function (length) {
                 console.log('%cin updateVesselLength()', 'color: #44aa33')
                 if (this.is_external && this.proposal) {

--- a/mooringlicensing/frontend/mooringlicensing/src/components/form_mla.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/form_mla.vue
@@ -295,27 +295,6 @@
             vesselChanged: async function(vesselChanged) {
                 await this.$emit("vesselChanged", vesselChanged);
             },
-            /*
-            updateVesselLength: function(length) {
-                let higherCategory = false;
-                if (this.is_external && this.proposal) {
-                    if (!this.proposal.previous_application_id) {
-                        // new application
-                        //higherCategory = true;
-                        //pass
-                    } else if (this.proposal.max_vessel_length_with_no_payment &&
-                        this.proposal.max_vessel_length_with_no_payment <= length) {
-                        // vessel length is in higher category
-                        higherCategory = true;
-                    }
-                }
-                console.log(higherCategory);
-                if (higherCategory) {
-                    this.showPaymentTab = true;
-                    this.$emit("updateSubmitText", "Pay / Submit");
-                }
-            },
-            */
             updateVesselLength: function (length) {
                 console.log('%cin updateVesselLength()', 'color: #44aa33')
                 if (this.is_external && this.proposal) {

--- a/mooringlicensing/frontend/mooringlicensing/src/components/form_wla.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/form_wla.vue
@@ -304,9 +304,12 @@ export default {
             }
             this.$nextTick(async () => {
                 // auto approve
+                console.log(!this.proposal.vessel_on_proposal, this.higherVesselCategory, !this.keepCurrentVessel, this.mooringPreferenceChanged, this.vesselOwnershipChanged)
                 if (!this.proposal.vessel_on_proposal || this.higherVesselCategory || !this.keepCurrentVessel || this.mooringPreferenceChanged || this.vesselOwnershipChanged) {
+                    console.log("AUTOAPPROVE FALSE")
                     await this.$emit("updateAutoApprove", false);
                 } else {
+                    console.log("AUTOAPPROVE TRUE")
                     await this.$emit("updateAutoApprove", true);
                 }
             })

--- a/mooringlicensing/frontend/mooringlicensing/src/components/internal/proposals/proposal.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/internal/proposals/proposal.vue
@@ -69,7 +69,6 @@
                         :key="computedProposalId"
                         @profile-fetched="populateProfile"
                         @updateSubmitText="updateSubmitText"
-                        @updateAutoApprove="updateAutoApprove"
                     />
 
                     <AnnualAdmissionApplication
@@ -83,7 +82,6 @@
                         :readonly="readonly"
                         @profile-fetched="populateProfile"
                         @updateSubmitText="updateSubmitText"
-                        @updateAutoApprove="updateAutoApprove"
                     />
                     <AuthorisedUserApplication
                         v-if="proposal && proposal.application_type_dict.code==='aua'"
@@ -95,7 +93,6 @@
                         :readonly="readonly"
                         @profile-fetched="populateProfile"
                         @updateSubmitText="updateSubmitText"
-                        @updateAutoApprove="updateAutoApprove"
                     />
                     <MooringLicenceApplication
                         v-if="proposal && proposal.application_type_dict.code==='mla'"
@@ -108,7 +105,6 @@
                         :readonly="readonly"
                         @profile-fetched="populateProfile"
                         @updateSubmitText="updateSubmitText"
-                        @updateAutoApprove="updateAutoApprove"
                     />
                 </template>
                 <template v-if="display_requirements">
@@ -206,7 +202,6 @@ export default {
     data: function() {
         let vm = this;
         return {
-            autoApprove: false,
             profile: {},
             savingProposal: false,
             submittingProposal: false,
@@ -557,11 +552,6 @@ export default {
 
             return payload;
         },
-        updateAutoApprove: function(approve) {
-            this.autoApprove = approve;
-            console.log('%cin updateAutoApprove', 'color: #990000')
-            console.log(this.autoApprove)
-        },
         updateSubmitText: function(submitText) {
             this.submitText = submitText;
         },
@@ -587,6 +577,9 @@ export default {
                 //we do not want to update that data if we need to immediately redirect (save_and_pay)
                 if (updateProposalData) {
                     vm.proposal = res.body;
+                }
+                if (res.body.auto_approve !== undefined) {
+                    vm.proposal.auto_approve = res.body.auto_approve;
                 }
                 vm.savingProposal=false;
                 this.submitRes = true;               
@@ -669,7 +662,7 @@ export default {
                     if (this.submitRes) {
                         let payload = this.buildPayload();
                         payload.csrfmiddlewaretoken = this.csrf_token;
-                        if (this.autoApprove) {
+                        if (this.proposal.auto_approve) {
                             this.post_and_redirect(this.application_fee_url, payload);
                         } else if (['wla', 'aaa'].includes(this.proposal.application_type_code)) {
                             this.post_and_redirect(this.application_fee_url, payload);

--- a/mooringlicensing/helpers.py
+++ b/mooringlicensing/helpers.py
@@ -76,6 +76,13 @@ def is_customer(request):
 def is_internal(request):
     return is_departmentUser(request)
 
+def is_authorised_to_pay_auto_approved(request, instance):
+    if (instance.auto_approve and 
+        (request.user.email == instance.applicant_email or is_internal(request))
+        ):
+        return True
+    return False
+
 def is_authorised_to_modify(request, instance):
     authorised = True
 


### PR DESCRIPTION
Existing Auto-Approve functions have been re-created in python on the server-side based on client-side vue/js functions. Decision to auto-approve an application will no longer be determined on the client-side where it can be potentially manipulated.

Stickers will now be set to expired (subject to their current status) when an approval is set to expired.

Various minor errors have also been fixed:
 - potentially infinite while loop fixed
 - sticker and approval search fixed
 - misapplied vessel ownership error(s) fixed