### PR TITLE
Fixed internal wla-allowed check

### DIFF
--- a/mooringlicensing/components/proposals/api.py
+++ b/mooringlicensing/components/proposals/api.py
@@ -953,7 +953,10 @@ class InternalWaitingListApplicationViewSet(viewsets.GenericViewSet):
                 except:
                     raise serializers.ValidationError("proposal type does not exist")
 
-                wla_allowed = get_wla_allowed(request.user.id)
+                if not system_user.ledger_id:
+                    raise serializers.ValidationError("system user does not have valid corresponding email user")
+
+                wla_allowed = get_wla_allowed(system_user.ledger_id.id)
                 if not wla_allowed:
                     raise serializers.ValidationError("user not permitted to create WLA at this time")
 


### PR DESCRIPTION
When submitting a WLA for an applicant, the submitter id was being incorrectly used to check if the user could submit a wla -  that is now fixed.