### PR TITLE
Workflow adjustments/fixes

### DIFF
--- a/mooringlicensing/components/payments_ml/views.py
+++ b/mooringlicensing/components/payments_ml/views.py
@@ -394,7 +394,6 @@ class ApplicationFeeView(TemplateView):
 
     def post(self, request, *args, **kwargs):
         proposal = self.get_object()
-
         try:
             #check for auto approval
             auto_approved = is_authorised_to_pay_auto_approved(request,proposal)

--- a/mooringlicensing/components/proposals/api.py
+++ b/mooringlicensing/components/proposals/api.py
@@ -1775,7 +1775,8 @@ class ProposalViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
             instance = self.get_object()
             is_applicant_address_set(instance)
 
-            return Response()
+            serializer = self.serializer_class(instance, context={'request':request})
+            return Response(serializer.data)
 
     @detail_route(methods=['GET',], detail=True)
     def get_max_vessel_length_for_main_component(self, request, *args, **kwargs):

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -3503,21 +3503,22 @@ class AuthorisedUserApplication(Proposal):
         self.log_user_action(ProposalUserAction.ACTION_LODGE_APPLICATION.format(self.lodgement_number), request)
         mooring_preference = self.get_mooring_authorisation_preference()
 
-        # if mooring_preference.lower() != 'ria' and self.proposal_type.code in [PROPOSAL_TYPE_NEW,]:
-        if ((mooring_preference.lower() != 'ria' and self.proposal_type.code == PROPOSAL_TYPE_NEW) or
-            (mooring_preference.lower() != 'ria' and self.proposal_type.code != PROPOSAL_TYPE_NEW and not self.keep_existing_mooring)):
-            # Mooring preference is 'site_licensee' and which is new mooring applying for.
-            self.processing_status = Proposal.PROCESSING_STATUS_AWAITING_ENDORSEMENT
-            self.save()
-            # Email to endorser
-            send_endorsement_of_authorised_user_application_email(request, self)
-            send_confirmation_email_upon_submit(request, self, False)
-        else:
-            self.processing_status = Proposal.PROCESSING_STATUS_WITH_ASSESSOR
-            self.save()
-            send_confirmation_email_upon_submit(request, self, False)
-            if not self.auto_approve:
-                send_notification_email_upon_submit_to_assessor(request, self)
+        if not (self.auto_approve and self.proposal_type.code == PROPOSAL_TYPE_RENEWAL):
+            # if mooring_preference.lower() != 'ria' and self.proposal_type.code in [PROPOSAL_TYPE_NEW,]:
+            if ((mooring_preference.lower() != 'ria' and self.proposal_type.code == PROPOSAL_TYPE_NEW) or
+                (mooring_preference.lower() != 'ria' and self.proposal_type.code != PROPOSAL_TYPE_NEW and not self.keep_existing_mooring)):
+                # Mooring preference is 'site_licensee' and which is new mooring applying for.
+                self.processing_status = Proposal.PROCESSING_STATUS_AWAITING_ENDORSEMENT
+                self.save()
+                # Email to endorser
+                send_endorsement_of_authorised_user_application_email(request, self)
+                send_confirmation_email_upon_submit(request, self, False)
+            else:
+                self.processing_status = Proposal.PROCESSING_STATUS_WITH_ASSESSOR
+                self.save()
+                send_confirmation_email_upon_submit(request, self, False)
+                if not self.auto_approve:
+                    send_notification_email_upon_submit_to_assessor(request, self)
 
     def update_or_create_approval(self, current_datetime, request=None):
         logger.info(f'Updating/Creating Authorised User Permit from the application: [{self}]...')

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -4578,18 +4578,20 @@ class Vessel(RevisionedMixin):
         logger.info(f'Checking blocking ownership for the proposal: [{proposal_being_processed}]...')
         from mooringlicensing.components.approvals.models import Approval, MooringLicence
 
-        if proposal_being_processed.proposal_applicant:
-            if self.filtered_vesselownership_set.exclude(owner__emailuser=proposal_being_processed.proposal_applicant.email_user_id):
-                raise serializers.ValidationError("This vessel is already listed with RIA under another owner")
-        else:
-            raise serializers.ValidationError("No valid proposal applicant provided")
+        #NOTE below check has been disabled
+        #a vessel CAN have multiple owners, subject to owner percentage, multiple owners cannot exist across multipe licenses (TODO review reqs)
+        # a vessel can be owned by multiple owners if their percentage is low enough
+        #if proposal_being_processed.proposal_applicant:
+        #    if self.filtered_vesselownership_set.exclude(owner__emailuser=proposal_being_processed.proposal_applicant.email_user_id):
+        #        raise serializers.ValidationError("This vessel is already listed with RIA under another owner")
+        #else:
+        #    raise serializers.ValidationError("No valid proposal applicant provided")
         
         #vessels can be:
         # 1 on multiple active approvals IF owned by the same person
         # 2 on only ONE active proposal at a time
-        # 3 by one owner only - other applicants may not use the vessel until the vessel has been sold (and all related proposals and approvals are no longer active)
 
-        ## Requirement: Vessel can only be listed as owned by one vessel owner until sold (with company ownership also considered)
+        ## Requirement: If vessel is owned by multiple parties then there must be no
         # 1. other application in status other than issued, declined or discarded where the applicant is another owner than this applicant
         proposals_filter = Q()  # This is condition for the proposal to be blocking proposal.
         proposals_filter &= Q(vessel_ownership__vessel=self)  # Blocking proposal is for the same vessel
@@ -4670,7 +4672,7 @@ class Vessel(RevisionedMixin):
                 )
 
 
-class VesselLogDocument(Document):
+class VesselLogDocument(Document):#
     log_entry = models.ForeignKey('VesselLogEntry',related_name='documents', on_delete=models.CASCADE)
     _file = models.FileField(storage=private_storage,upload_to=update_vessel_comms_log_filename, max_length=512)
 

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -2397,7 +2397,6 @@ class Proposal(DirtyFieldsMixin, RevisionedMixin):
         return False
     
     def vessel_ownership_changed(self):
-
         previous_ownership = None
         if self.previous_application:
             previous_ownership = self.previous_application.vessel_ownership
@@ -2417,10 +2416,10 @@ class Proposal(DirtyFieldsMixin, RevisionedMixin):
                         previous_company_ownership.percentage != company_ownership.percentage
                     ):
                         return True
-            else:
-                if not self.vessel_ownership.individual_owner:
+            else: #no previous company ownership
+                if not self.vessel_ownership.individual_owner: #company ownership
                     return True
-
+                
         return False
 
     def mooring_changed(self):

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -3503,7 +3503,7 @@ class AuthorisedUserApplication(Proposal):
         self.log_user_action(ProposalUserAction.ACTION_LODGE_APPLICATION.format(self.lodgement_number), request)
         mooring_preference = self.get_mooring_authorisation_preference()
 
-        if not (self.auto_approve and self.proposal_type.code == PROPOSAL_TYPE_RENEWAL):
+        if not (self.auto_approve and (self.proposal_type.code == PROPOSAL_TYPE_RENEWAL or self.proposal_type.code == PROPOSAL_TYPE_AMENDMENT)):
             # if mooring_preference.lower() != 'ria' and self.proposal_type.code in [PROPOSAL_TYPE_NEW,]:
             if ((mooring_preference.lower() != 'ria' and self.proposal_type.code == PROPOSAL_TYPE_NEW) or
                 (mooring_preference.lower() != 'ria' and self.proposal_type.code != PROPOSAL_TYPE_NEW and not self.keep_existing_mooring)):

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -2369,10 +2369,11 @@ class Proposal(DirtyFieldsMixin, RevisionedMixin):
         from mooringlicensing.components.proposals.utils import get_max_vessel_length_for_main_component
         max_vessel_length_with_no_payment = get_max_vessel_length_for_main_component(self)
         length = 0
-        if (max_vessel_length_with_no_payment[0] < self.vessel_length or (
-            max_vessel_length_with_no_payment[0] == self.vessel_length and
-            not max_vessel_length_with_no_payment[1])):
-            return True
+        if self.vessel_length:
+            if (max_vessel_length_with_no_payment[0] < self.vessel_length or (
+                max_vessel_length_with_no_payment[0] == self.vessel_length and
+                not max_vessel_length_with_no_payment[1])):
+                return True
         return False
     
     def keeping_current_vessel(self):

--- a/mooringlicensing/components/proposals/serializers.py
+++ b/mooringlicensing/components/proposals/serializers.py
@@ -695,7 +695,7 @@ class SaveWaitingListApplicationSerializer(serializers.ModelSerializer):
                 if not self.instance.electoral_roll_documents.all():
                     custom_errors["Silent Elector"] = "You must provide evidence of this"
             
-            # When company ownership, vessel registration document is compalsory
+            # When company ownership, vessel registration document is compulsory
             if not self.instance.vessel_ownership.individual_owner:
                 if not self.instance.vessel_ownership.vessel_registration_documents.count():
                     custom_errors["Copy of registration papers"] = "You must provide evidence of this"

--- a/mooringlicensing/components/proposals/utils.py
+++ b/mooringlicensing/components/proposals/utils.py
@@ -365,6 +365,7 @@ def save_proponent_data(instance, request, action, being_auto_approved=False):
         elif type(instance.child_obj) == MooringLicenceApplication:
             save_proponent_data_mla(instance, request, action) 
 
+        instance.refresh_from_db()
         if instance.proposal_applicant and instance.proposal_applicant.email_user_id == request.user.id:
             # Save request.user details in a JSONField not to overwrite the details of it.
             try:

--- a/mooringlicensing/components/proposals/utils.py
+++ b/mooringlicensing/components/proposals/utils.py
@@ -377,8 +377,6 @@ def save_proponent_data(instance, request, action, being_auto_approved=False):
             except Exception as e:
                 print(e)
                 raise serializers.ValidationError("error")
-            
-        instance.child_obj.set_auto_approve(request)
     else:
         raise serializers.ValidationError("user not authorised to update applicant details")
 
@@ -411,6 +409,7 @@ def save_proponent_data_aaa(instance, request, action):
     logger.info(f'Update the Proposal: [{instance}] with the data: [{proposal_data}].')
 
     update_proposal_applicant(instance.child_obj, request)
+    instance.child_obj.set_auto_approve(request)
     if action == 'submit':
         # if instance.invoice and instance.invoice.payment_status in ['paid', 'over_paid']:
         if instance.invoice and get_invoice_payment_status(instance.id) in ['paid', 'over_paid']:
@@ -448,6 +447,7 @@ def save_proponent_data_wla(instance, request, action):
     logger.info(f'Update the Proposal: [{instance}] with the data: [{proposal_data}].')
 
     update_proposal_applicant(instance.child_obj, request)
+    instance.child_obj.set_auto_approve(request)
     if action == 'submit':
         # if instance.invoice and instance.invoice.payment_status in ['paid', 'over_paid']:
         if instance.invoice and get_invoice_payment_status(instance.invoice.id) in ['paid', 'over_paid']:
@@ -487,6 +487,7 @@ def save_proponent_data_mla(instance, request, action):
     logger.info(f'Update the Proposal: [{instance}] with the data: [{proposal_data}].')
 
     update_proposal_applicant(instance.child_obj, request)
+    instance.child_obj.set_auto_approve(request)
     if action == 'submit':
         instance.child_obj.process_after_submit(request)
         instance.refresh_from_db()
@@ -531,6 +532,7 @@ def save_proponent_data_aua(instance, request, action):
     logger.info(f'Update the Proposal: [{instance}] with the data: [{proposal_data}].')
 
     update_proposal_applicant(instance.child_obj, request)
+    instance.child_obj.set_auto_approve(request)
     if action == 'submit':
         instance.child_obj.process_after_submit(request)
         instance.refresh_from_db()

--- a/mooringlicensing/components/proposals/utils.py
+++ b/mooringlicensing/components/proposals/utils.py
@@ -994,7 +994,8 @@ def ownership_percentage_validation(vessel_ownership, proposal):
 
     total_percent = vessel_ownership_percentage
     vessel = vessel_ownership.vessel
-    for vo in vessel.filtered_vesselownership_set.all():
+
+    for vo in vessel.filtered_vesselownership_set.distinct('owner'): 
         if vo in previous_vessel_ownerships:
             # We don't want to count the percentage in the previous vessel ownerships
             continue
@@ -1006,8 +1007,8 @@ def ownership_percentage_validation(vessel_ownership, proposal):
                         company_ownership.percentage and
                         company_ownership.blocking_proposal
                 ):
-                    total_percent += vo.company_ownership.percentage
-                    logger.info(f'Vessel ownership to be taken into account in the calculation: {vo.company_ownership}')
+                    total_percent += company_ownership.percentage
+                    logger.info(f'Vessel ownership to be taken into account in the calculation: {company_ownership}')
         elif vo.percentage and vo.id != individual_ownership_id:
             total_percent += vo.percentage
             logger.info(f'Vessel ownership to be taken into account in the calculation: {vo}')

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/vessels.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/vessels.vue
@@ -505,8 +505,8 @@ export default {
                                 }
                             }
                         }
-                    } else {
-                        if (!this.vesselOwnership.individual_owner) {
+                    } else { //not company ownership
+                        if (!this.vesselOwnership.individual_owner) { //company ownership
                             // Individual ownership --> Company ownership
                             vesselOwnershipChanged = true
                         }


### PR DESCRIPTION
Some fixes to auto-approve checks

Fixed status update for auto-approved AUPs that have not been paid for yet (remain in draft until paid)

Added distinct check on vessel owner owners for percentage validation

Disabled single owner restriction (though only one owner can have active approvals still