### PR TITLE
Miscellaneous Fixes and Adjustments

### DIFF
--- a/mooringlicensing/components/approvals/models.py
+++ b/mooringlicensing/components/approvals/models.py
@@ -1625,6 +1625,7 @@ class AuthorisedUserPermit(Approval):
             # Set end_date to the moa because the mooring on it is no longer available.
             moa = self.mooringonapproval_set.get(mooring__mooring_licence=mooring_licence)
             if not moa.end_date:
+                moa.active = False
                 moa.end_date = datetime.datetime.now().date()
                 moa.save()
                 logger.info(f'Set end_date: [{moa.end_date}] to the MooringOnApproval: [{moa}] because the Mooring: [{moa.mooring}] is no longer available.')

--- a/mooringlicensing/components/payments_ml/models.py
+++ b/mooringlicensing/components/payments_ml/models.py
@@ -604,10 +604,9 @@ class FeeConstructor(models.Model):
                             #     # No fee_items created
                             #     continue
                             if (
-                                    (vessel_size_category.null_vessel and proposal_type.code in [settings.PROPOSAL_TYPE_NEW,]) or
+                                    #(vessel_size_category.null_vessel and proposal_type.code in [settings.PROPOSAL_TYPE_NEW,]) or
                                     (vessel_size_category.null_vessel and self.application_type.code in [AnnualAdmissionApplication.code, AuthorisedUserApplication.code,]) or
                                     (not fee_period.is_first_period and proposal_type.code in [settings.PROPOSAL_TYPE_RENEWAL,])
-                                    # When null vessel and new proposal (any application type), OR
                                     # When null vessel and AnnualAdmissionApplication/AuthorisedUserApplication <== When renew the ML with null vessel, do we need nul vessel AA fee_item...???
                                     # When first period and renewal proposal
                             ):

--- a/mooringlicensing/components/proposals/api.py
+++ b/mooringlicensing/components/proposals/api.py
@@ -2357,7 +2357,7 @@ class VesselViewSet(viewsets.ModelViewSet):
     @basic_exception_handler
     def lookup_vessel_ownership(self, request, *args, **kwargs):
         vessel = self.get_object()
-        serializer = VesselFullOwnershipSerializer(vessel.filtered_vesselownership_set.all(), many=True)
+        serializer = VesselFullOwnershipSerializer(vessel.filtered_vesselownership_set.distinct("owner"), many=True)
         return Response(serializer.data)
 
     @detail_route(methods=['GET',], detail=True)
@@ -2458,7 +2458,7 @@ class VesselViewSet(viewsets.ModelViewSet):
         else:
             raise serializers.ValidationError("no email user id provided")
 
-        vessel_ownership_list = owner.vesselownership_set.all()
+        vessel_ownership_list = owner.vesselownership_set.distinct("vessel")
 
         # TODO review - rewrite following for vessel_ownership_list
         if search_text:
@@ -2485,7 +2485,7 @@ class VesselViewSet(viewsets.ModelViewSet):
         owner_qs = Owner.objects.filter(emailuser=request.user.id)
         if owner_qs:
             owner = owner_qs[0]
-            vessel_ownership_list = owner.vesselownership_set.all()
+            vessel_ownership_list = owner.vesselownership_set.distinct("vessel")
 
             # rewrite following for vessel_ownership_list
             if search_text:

--- a/mooringlicensing/components/proposals/api.py
+++ b/mooringlicensing/components/proposals/api.py
@@ -1686,13 +1686,16 @@ class ProposalViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
     @detail_route(methods=['POST',], detail=True)
     @basic_exception_handler
     def proposed_approval(self, request, *args, **kwargs):
-        instance = self.get_object()
-        serializer = ProposedApprovalSerializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        instance.proposed_approval(request, serializer.validated_data)
-        serializer_class = self.internal_serializer_class()
-        serializer = serializer_class(instance,context={'request':request})
-        return Response(serializer.data)
+        if is_internal(request):
+            instance = self.get_object()
+            serializer = ProposedApprovalSerializer(data=request.data)
+            serializer.is_valid(raise_exception=True)
+            instance.proposed_approval(request, serializer.validated_data)
+            serializer_class = self.internal_serializer_class()
+            serializer = serializer_class(instance,context={'request':request})
+            return Response(serializer.data)
+        else:
+            raise serializers.ValidationError("not authorised to assess proposal")
 
     @detail_route(methods=['POST',], detail=True)
     @basic_exception_handler

--- a/mooringlicensing/components/proposals/api.py
+++ b/mooringlicensing/components/proposals/api.py
@@ -2289,12 +2289,13 @@ class VesselViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         queryset = Vessel.objects.none()
         user = self.request.user
-        if is_internal(self.request):
-            queryset = Vessel.objects.all().order_by('id')
-        elif is_customer(self.request):
-            owner = Owner.objects.filter(emailuser=user.id)
-            if owner:
-                queryset = owner.first().vessels.distinct()
+        queryset = Vessel.objects.all().order_by('id')
+        #if is_internal(self.request):
+        #    queryset = Vessel.objects.all().order_by('id')
+        #elif is_customer(self.request):
+        #    owner = Owner.objects.filter(emailuser=user.id)
+        #    if owner:
+        #        queryset = owner.first().vessels.distinct()
         return queryset
 
     @detail_route(methods=['POST',], detail=True)
@@ -2357,7 +2358,10 @@ class VesselViewSet(viewsets.ModelViewSet):
     @basic_exception_handler
     def lookup_vessel_ownership(self, request, *args, **kwargs):
         vessel = self.get_object()
-        serializer = VesselFullOwnershipSerializer(vessel.filtered_vesselownership_set.distinct("owner"), many=True)
+        if is_internal(request):
+            serializer = VesselFullOwnershipSerializer(vessel.filtered_vesselownership_set.distinct("owner"), many=True)
+        else:
+            serializer = VesselFullOwnershipSerializer(vessel.filtered_vesselownership_set.filter(owner__emailuser=request.user.id).distinct("owner"), many=True)
         return Response(serializer.data)
 
     @detail_route(methods=['GET',], detail=True)

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -3637,9 +3637,11 @@ class AuthorisedUserApplication(Proposal):
                     # convert proposed_issuance_approval to an end_date
                     if moa1.get("id") == moa2.id and not moa1.get("checked") and not moa2.end_date:
                         moa2.end_date = current_datetime.date()
+                        moa2.active = False
                         moa2.save()
                     elif moa1.get("id") == moa2.id and moa1.get("checked") and moa2.end_date:
                         moa2.end_date = None
+                        moa2.active = True
                         moa2.save()
         # set auto_approve renewal application ProposalRequirement due dates to those from previous application + 12 months
         if self.auto_approve and self.proposal_type.code == PROPOSAL_TYPE_RENEWAL:

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -2938,8 +2938,10 @@ class WaitingListApplication(Proposal):
 
     @property
     def does_accept_null_vessel(self):
-        if self.proposal_type.code in [PROPOSAL_TYPE_AMENDMENT, PROPOSAL_TYPE_RENEWAL,]:
-            return True
+        #MLA and WLA do not need a vessel to be submitted
+        return True
+        #if self.proposal_type.code in [PROPOSAL_TYPE_AMENDMENT, PROPOSAL_TYPE_RENEWAL,]:
+        #    return True
         # return False
 
     def process_after_approval(self, request=None, total_amount=0):
@@ -4250,9 +4252,11 @@ class MooringLicenceApplication(Proposal):
 
     @property
     def does_accept_null_vessel(self):
-        if self.proposal_type.code in [PROPOSAL_TYPE_RENEWAL, PROPOSAL_TYPE_AMENDMENT, PROPOSAL_TYPE_SWAP_MOORINGS,]:
-            return True
-        return False
+        #MLA and WLA do not need a vessel to be submitte
+        return True
+        #if self.proposal_type.code in [PROPOSAL_TYPE_RENEWAL, PROPOSAL_TYPE_AMENDMENT, PROPOSAL_TYPE_SWAP_MOORINGS,]:
+        #    return True
+        #return False
 
     def does_have_valid_associations(self):
         """

--- a/mooringlicensing/components/proposals/serializers.py
+++ b/mooringlicensing/components/proposals/serializers.py
@@ -1119,7 +1119,7 @@ class InternalProposalSerializer(BaseProposalSerializer):
     def get_authorised_user_moorings(self, obj):
         moorings = []
         if type(obj.child_obj) == AuthorisedUserApplication and obj.approval:
-            for moa in obj.approval.mooringonapproval_set.filter(active=True):
+            for moa in obj.approval.mooringonapproval_set.all():
                 # if moa.mooring.mooring_licence is not None:
                 #     suitable_for_mooring = True
                 #     # only do check if vessel details exist
@@ -1148,7 +1148,7 @@ class InternalProposalSerializer(BaseProposalSerializer):
                 #import ipdb; ipdb.set_trace()
 
                 # Retrieve checkbox status for this mooring (moa.mooring)
-                checked = True
+                checked = moa.active
                 if obj.proposed_issuance_approval and 'mooring_on_approval' in obj.proposed_issuance_approval:
                     for item in obj.proposed_issuance_approval['mooring_on_approval']:
                         if  moa.id == item['id']:

--- a/mooringlicensing/components/proposals/serializers.py
+++ b/mooringlicensing/components/proposals/serializers.py
@@ -696,7 +696,7 @@ class SaveWaitingListApplicationSerializer(serializers.ModelSerializer):
                     custom_errors["Silent Elector"] = "You must provide evidence of this"
             
             # When company ownership, vessel registration document is compulsory
-            if not self.instance.vessel_ownership.individual_owner:
+            if self.instance.vessel_ownership  and not self.instance.vessel_ownership.individual_owner:
                 if not self.instance.vessel_ownership.vessel_registration_documents.count():
                     custom_errors["Copy of registration papers"] = "You must provide evidence of this"
 

--- a/mooringlicensing/components/proposals/utils.py
+++ b/mooringlicensing/components/proposals/utils.py
@@ -638,9 +638,9 @@ def submit_vessel_data(instance, request, vessel_data):
             raise serializers.ValidationError(vessel_lookup_errors)
 
     if not vessel_data.get('rego_no'):
-        if instance.proposal_type.code in [PROPOSAL_TYPE_RENEWAL, PROPOSAL_TYPE_AMENDMENT, PROPOSAL_TYPE_SWAP_MOORINGS,]:
-            if type(instance.child_obj) in [MooringLicenceApplication, WaitingListApplication,]:
-                return
+        #MLA and WLA do not need a vessel to be submitted
+        if type(instance.child_obj) in [MooringLicenceApplication, WaitingListApplication,]:
+            return
         else:
             raise serializers.ValidationError("Application cannot be submitted without a vessel listed")
 

--- a/mooringlicensing/components/proposals/utils.py
+++ b/mooringlicensing/components/proposals/utils.py
@@ -828,7 +828,7 @@ def store_vessel_ownership(request, vessel, instance):
     elif instance.proposal_type.code in [PROPOSAL_TYPE_AMENDMENT, PROPOSAL_TYPE_RENEWAL, PROPOSAL_TYPE_SWAP_MOORINGS,]:
         # Retrieve a vessel_ownership from the previous proposal
         # vessel_ownership = instance.previous_application.vessel_ownership  # !!! This is not always true when ML !!!
-        vessel_ownership = instance.vessel_ownership if instance.vessel_ownership else instance.get_latest_vessel_ownership_by_vessel(vessel)
+        vessel_ownership = instance.vessel_ownership if instance.vessel_ownership != None else instance.get_latest_vessel_ownership_by_vessel(vessel)
 
         vessel_ownership_to_be_created = False
         if vessel_ownership and vessel_ownership.end_date:
@@ -851,7 +851,8 @@ def store_vessel_ownership(request, vessel, instance):
                 vessel_ownership_to_be_created = True
 
         #set vessel_ownership_to_be_created to true if switch between individual/company ownership
-        if ("individual_owner" in vessel_ownership_data and 
+        if (vessel_ownership and
+            "individual_owner" in vessel_ownership_data and 
             vessel_ownership_data["individual_owner"] != vessel_ownership.individual_owner):
             vessel_ownership_to_be_created = True
 

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/vessels.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/vessels.vue
@@ -897,9 +897,11 @@ export default {
             const vesselData = res.body;
             // read in vessel ownership data from Proposal if in Draft status
             if (this.proposal && this.proposal.processing_status === 'Draft' && !this.proposal.pending_amendment_request) {
-                if (vesselData && vesselData.rego_no) {
+                if (vesselData && vesselData.rego_no ) {
                     this.vessel.vessel_details = Object.assign({}, vesselData.vessel_details);
-                    this.vessel.vessel_ownership = Object.assign({}, vesselData.vessel_ownership);
+                    if (Object.keys(vesselData.vessel_ownership).length) {
+                        this.vessel.vessel_ownership = Object.assign({}, vesselData.vessel_ownership);
+                    }
                     this.vessel.id = vesselData.id;
                     this.vessel.rego_no = vesselData.rego_no;
                     //this.vessel.read_only = true;


### PR DESCRIPTION
- Vessel ownership listings now only show latest (i.e. relevant) instance (instead displaying the same vessel-owner pairs multiple times)
- WLA (and MLA) no longer require a vessel to be submitted (but are still subject to approval restrictions)
- Users can now look up vessels owned by other users (pii withheld) in case joint ownership is possible
- AUPs must now have at least one mooring to be approved
 
And minor bug fixes and workflow adjustments as needed