### PR TITLE
AAA printing and auto approval adjustments

### DIFF
--- a/mooringlicensing/components/approvals/api.py
+++ b/mooringlicensing/components/approvals/api.py
@@ -1437,7 +1437,7 @@ class StickerViewSet(viewsets.ModelViewSet):
         sticker = self.get_object()
         data = request.data
 
-        if not sticker.printing_date:
+        if not sticker.printing_date or not (self.status == "to_be_returned"):
             raise serializers.ValidationError("cannot return a sticker that has not yet been printed")
 
         # Update Sticker action
@@ -1459,7 +1459,7 @@ class StickerViewSet(viewsets.ModelViewSet):
         sticker = self.get_object()
         data = request.data
 
-        if not sticker.printing_date:
+        if not sticker.printing_date or not (self.status == "current" or self.status == "to_be_returned"):
             raise serializers.ValidationError("cannot lose a sticker that has not yet been printed")
 
         # Update Sticker action
@@ -1486,6 +1486,9 @@ class StickerViewSet(viewsets.ModelViewSet):
         sticker = self.get_object()
         # data = request.data
         data = {}
+
+        if not sticker.printing_date or not (self.status == "current"):
+            raise serializers.ValidationError("cannot replace a sticker that has not yet been printed")
 
         # Update Sticker action
         data['sticker'] = sticker.id

--- a/mooringlicensing/components/approvals/api.py
+++ b/mooringlicensing/components/approvals/api.py
@@ -1437,6 +1437,9 @@ class StickerViewSet(viewsets.ModelViewSet):
         sticker = self.get_object()
         data = request.data
 
+        if not sticker.printing_date:
+            raise serializers.ValidationError("cannot return a sticker that has not yet been printed")
+
         # Update Sticker action
         data['sticker'] = sticker.id
         data['action'] = 'Record returned'
@@ -1455,6 +1458,9 @@ class StickerViewSet(viewsets.ModelViewSet):
     def record_lost(self, request, *args, **kwargs):
         sticker = self.get_object()
         data = request.data
+
+        if not sticker.printing_date:
+            raise serializers.ValidationError("cannot lose a sticker that has not yet been printed")
 
         # Update Sticker action
         data['sticker'] = sticker.id

--- a/mooringlicensing/components/approvals/models.py
+++ b/mooringlicensing/components/approvals/models.py
@@ -3198,33 +3198,36 @@ class Sticker(models.Model):
             return f'ID: {self.id} (#---, {self.status})'
 
     def record_lost(self):
-        logger.info(f'record_lost() is being accessed for the sticker: [{self}].')
-        self.status = Sticker.STICKER_STATUS_LOST
-        self.save()
-        logger.info(f'Status: [{Sticker.STICKER_STATUS_LOST}] has been set to the sticker: [{self}].')
+        if (self.status.code == "current" or self.status.code == "to_be_returned") and self.printing_date:
+            logger.info(f'record_lost() is being accessed for the sticker: [{self}].')
+            self.status = Sticker.STICKER_STATUS_LOST
+            self.save()
+            logger.info(f'Status: [{Sticker.STICKER_STATUS_LOST}] has been set to the sticker: [{self}].')
 
     def record_returned(self):
-        logger.info(f'record_returned() is being accessed for the sticker: [{self}].')
-        self.status = Sticker.STICKER_STATUS_RETURNED
-        self.save()
-        logger.info(f'Status: [{Sticker.STICKER_STATUS_RETURNED}] has been set to the sticker: [{self}].')
+        if (self.status.code == "to_be_returned") and self.printing_date:
+            logger.info(f'record_returned() is being accessed for the sticker: [{self}].')
+            self.status = Sticker.STICKER_STATUS_RETURNED
+            self.save()
+            logger.info(f'Status: [{Sticker.STICKER_STATUS_RETURNED}] has been set to the sticker: [{self}].')
 
     def request_replacement(self, new_status):
-        logger.info(f'record_replacement() is being accessed for the sticker: [{self}].')
-        self.status = new_status
-        self.save()
-        logger.info(f'Status: [{new_status}] has been set to the sticker: [{self}].')
+        if (self.status.code == "current") and self.printing_date:
+            logger.info(f'record_replacement() is being accessed for the sticker: [{self}].')
+            self.status = new_status
+            self.save()
+            logger.info(f'Status: [{new_status}] has been set to the sticker: [{self}].')
 
-        # Create replacement sticker
-        new_sticker = Sticker.objects.create(
-            approval=self.approval,
-            vessel_ownership=self.vessel_ownership,
-            fee_constructor=self.fee_constructor,
-            fee_season=self.approval.latest_applied_season,
-        )
-        logger.info(f'New Sticker: [{new_sticker}] has been created for the approval: [{self.approval}].')
+            # Create replacement sticker
+            new_sticker = Sticker.objects.create(
+                approval=self.approval,
+                vessel_ownership=self.vessel_ownership,
+                fee_constructor=self.fee_constructor,
+                fee_season=self.approval.latest_applied_season,
+            )
+            logger.info(f'New Sticker: [{new_sticker}] has been created for the approval: [{self.approval}].')
 
-        return new_sticker
+            return new_sticker
 
     def get_sticker_colour(self):
         # colour = self.approval.child_obj.sticker_colour

--- a/mooringlicensing/components/approvals/models.py
+++ b/mooringlicensing/components/approvals/models.py
@@ -3198,21 +3198,21 @@ class Sticker(models.Model):
             return f'ID: {self.id} (#---, {self.status})'
 
     def record_lost(self):
-        if (self.status.code == "current" or self.status.code == "to_be_returned") and self.printing_date:
+        if (self.status == "current" or self.status == "to_be_returned") and self.printing_date:
             logger.info(f'record_lost() is being accessed for the sticker: [{self}].')
             self.status = Sticker.STICKER_STATUS_LOST
             self.save()
             logger.info(f'Status: [{Sticker.STICKER_STATUS_LOST}] has been set to the sticker: [{self}].')
 
     def record_returned(self):
-        if (self.status.code == "to_be_returned") and self.printing_date:
+        if (self.status == "to_be_returned") and self.printing_date:
             logger.info(f'record_returned() is being accessed for the sticker: [{self}].')
             self.status = Sticker.STICKER_STATUS_RETURNED
             self.save()
             logger.info(f'Status: [{Sticker.STICKER_STATUS_RETURNED}] has been set to the sticker: [{self}].')
 
     def request_replacement(self, new_status):
-        if (self.status.code == "current") and self.printing_date:
+        if (self.status == "current") and self.printing_date:
             logger.info(f'record_replacement() is being accessed for the sticker: [{self}].')
             self.status = new_status
             self.save()

--- a/mooringlicensing/components/approvals/signals.py
+++ b/mooringlicensing/components/approvals/signals.py
@@ -36,6 +36,7 @@ class StickerListener(object):
                 else:
                     logger.info(f'Proposal: [{sticker_saved.proposal_initiated}] still has sticker(s) being printed.')
         elif sticker_saved.status in [Sticker.STICKER_STATUS_LOST, Sticker.STICKER_STATUS_RETURNED,]:
+
             stickers_to_be_returned = sticker_saved.approval.stickers.filter(status=Sticker.STICKER_STATUS_TO_BE_RETURNED)
             proposals_initiated = []
 
@@ -90,6 +91,12 @@ class StickerListener(object):
                             proposal.processing_status = Proposal.PROCESSING_STATUS_PRINTING_STICKER
                             proposal.save()
                             logger.info(f'Status: [{Proposal.PROCESSING_STATUS_PRINTING_STICKER}] has been set to the proposal: [{proposal}]')
+        elif sticker_saved.status in [Sticker.STICKER_STATUS_TO_BE_RETURNED,]:
+            if sticker_saved.proposal_initiated.processing_status == Proposal.PROCESSING_STATUS_PRINTING_STICKER:
+                sticker_saved.proposal_initiated.processing_status = Proposal.PROCESSING_STATUS_APPROVED
+                sticker_saved.proposal_initiated.save()
+                logger.info(f'Status: [{Proposal.PROCESSING_STATUS_APPROVED}] has been set to the proposal: [{sticker_saved.proposal_initiated}]')
+            
 
         # Update the latest approval history for the approval this sticker is for
         latest_approval_history = ApprovalHistory.objects.filter(approval=sticker_saved.approval, end_date__isnull=True).order_by('-start_date')

--- a/mooringlicensing/components/payments_ml/views.py
+++ b/mooringlicensing/components/payments_ml/views.py
@@ -824,6 +824,9 @@ class ApplicationFeeSuccessViewPreload(APIView):
                         proposal.processing_status = Proposal.PROCESSING_STATUS_WITH_ASSESSOR
                         proposal.save()
                         logger.info(f'Processing status: [{Proposal.PROCESSING_STATUS_WITH_ASSESSOR}] has been set to the proposal: [{proposal}]')
+                        if proposal.application_type.code == AnnualAdmissionApplication.code and proposal.auto_approve:
+                            current_datetime = datetime.datetime.now()
+                            proposal.update_or_create_approval(current_datetime, request)   
 
                 else:
                     # msg = 'Invoice: {} payment status is {}.  It should be either paid or over_paid'.format(invoice.reference, invoice.payment_status)

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -2759,8 +2759,8 @@ class WaitingListApplication(Proposal):
     
     def set_auto_approve(self,request):
         #check WLA auto approval conditions
-        if (self.is_assessor(request) or 
-            self.is_approver(request) or
+        if (self.is_assessor(request.user) or 
+            self.is_approver(request.user) or
             (self.proposal_applicant and 
             self.proposal_applicant.email_user_id == request.user.id)
             ):
@@ -3054,15 +3054,16 @@ class AnnualAdmissionApplication(Proposal):
 
     def set_auto_approve(self,request):
         #check AAA auto approval conditions
-        #for AAA auto-approve just means if it is paid for right away
-        #and it always is
-        if (self.is_assessor(request) or 
-            self.is_approver(request) or
+        if (self.is_assessor(request.user) or 
+            self.is_approver(request.user) or
             (self.proposal_applicant and 
             self.proposal_applicant.email_user_id == request.user.id)
             ):
-            self.auto_approve = True
-            self.save()
+            if self.proposal_type and (
+            self.proposal_type.code == PROPOSAL_TYPE_AMENDMENT or 
+            self.proposal_type.code == PROPOSAL_TYPE_RENEWAL):
+                self.auto_approve = True
+                self.save()
 
     def validate_against_existing_proposals_and_approvals(self):
         from mooringlicensing.components.approvals.models import Approval, ApprovalHistory, AnnualAdmissionPermit, MooringLicence, AuthorisedUserPermit
@@ -3550,8 +3551,8 @@ class AuthorisedUserApplication(Proposal):
 
     def set_auto_approve(self,request):
         #check AUP auto approval conditions
-        if (self.is_assessor(request) or 
-            self.is_approver(request) or
+        if (self.is_assessor(request.user) or 
+            self.is_approver(request.user) or
             (self.proposal_applicant and 
             self.proposal_applicant.email_user_id == request.user.id)
             ):
@@ -4109,8 +4110,8 @@ class MooringLicenceApplication(Proposal):
 
     def set_auto_approve(self,request):
         #check AUP auto approval conditions
-        if (self.is_assessor(request) or 
-            self.is_approver(request) or
+        if (self.is_assessor(request.user) or 
+            self.is_approver(request.user) or
             (self.proposal_applicant and 
             self.proposal_applicant.email_user_id == request.user.id)
             ):

--- a/mooringlicensing/components/proposals/utils.py
+++ b/mooringlicensing/components/proposals/utils.py
@@ -412,6 +412,7 @@ def save_proponent_data_aaa(instance, request, action):
     update_proposal_applicant(instance.child_obj, request)
     instance.refresh_from_db()
     instance.child_obj.set_auto_approve(request)
+    instance.refresh_from_db()
     if action == 'submit':
         # if instance.invoice and instance.invoice.payment_status in ['paid', 'over_paid']:
         if instance.invoice and get_invoice_payment_status(instance.id) in ['paid', 'over_paid']:
@@ -420,6 +421,9 @@ def save_proponent_data_aaa(instance, request, action):
             logger.info('Proposal {} has been submitted but already paid.  Update the status of it to {}'.format(instance.lodgement_number, Proposal.PROCESSING_STATUS_WITH_ASSESSOR))
             instance.processing_status = Proposal.PROCESSING_STATUS_WITH_ASSESSOR
             instance.save()
+            if instance.auto_approve:
+                current_datetime = datetime.datetime.now()
+                instance.update_or_create_approval(current_datetime, request)       
 
 
 def save_proponent_data_wla(instance, request, action):

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/table_stickers.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/table_stickers.vue
@@ -412,8 +412,10 @@ export default {
                 case 'lost':
                     break
                 case 'to_be_returned':
-                    links += `<a href='#${sticker.id}' data-record-returned='${sticker.id}'>Record Returned Sticker</a><br/>`
-                    links += `<a href='#${sticker.id}' data-record-lost='${sticker.id}'>Record Sticker Lost</a><br/>`
+                    if (sticker.printing_date !== "" && sticker.printing_date !== null) {
+                        links += `<a href='#${sticker.id}' data-record-returned='${sticker.id}'>Record Returned Sticker</a><br/>`
+                        links += `<a href='#${sticker.id}' data-record-lost='${sticker.id}'>Record Sticker Lost</a><br/>`
+                    }
                     break
                 case 'returned':
                     break

--- a/mooringlicensing/templates/mooringlicensing/base.html
+++ b/mooringlicensing/templates/mooringlicensing/base.html
@@ -139,13 +139,13 @@
                                                 {% if is_mooringlicensing_admin_user or request.user.is_superuser %}
                                                     <li role="separator" class="divider"></li>
                                                 {% endif %}
-                                                {% if is_account_management_user or request.user.is_superuser %}
+                                                {% if is_mooringlicensing_admin_user or request.user.is_superuser %}
                                                     <li><a href="{% url 'mgt-commands' %}">Management Commands</a></li>
                                                 {% endif %}
                                                 {% if show_tests and request.user.is_superuser %}
                                                     <li><a href="{% url 'test-emails' %}">Test Emails</a></li>
                                                 {% endif %}
-                                                {% if is_mooringlicensing_admin_user or request.user.is_superuser %}
+                                                {% if is_account_management_user or request.user.is_superuser %}
                                                     <li><a class="dropdown-item" href="/ledger-ui/accounts-management">Accounts Management</a></li>
                                                 {% endif %}
                                                     <li><a class="dropdown-item" href="/ledger-ui/system-accounts">Manage Account</a></li>


### PR DESCRIPTION
When an AAA amendment is made before a sticker is printed, the original proposal will now be properly updated when the old sticker is printed. Said old sticker cannot be recorded as returned until printed (or lost). 

AAA auto approval now actually works, skipping the assessor stage when the relevant conditions are met - for amendments and renewals only. Stickers handling is still handled based on the amendment/renewal changes.

Some changes to sticker handling may also correct behaviours for other application types, and will be tested.