### PR TITLE
AUP printing adjustments

### DIFF
--- a/mooringlicensing/components/approvals/api.py
+++ b/mooringlicensing/components/approvals/api.py
@@ -1437,7 +1437,7 @@ class StickerViewSet(viewsets.ModelViewSet):
         sticker = self.get_object()
         data = request.data
 
-        if not sticker.printing_date or not (self.status == "to_be_returned"):
+        if not sticker.printing_date or not (sticker.status == "to_be_returned"):
             raise serializers.ValidationError("cannot return a sticker that has not yet been printed")
 
         # Update Sticker action
@@ -1459,7 +1459,7 @@ class StickerViewSet(viewsets.ModelViewSet):
         sticker = self.get_object()
         data = request.data
 
-        if not sticker.printing_date or not (self.status == "current" or self.status == "to_be_returned"):
+        if not sticker.printing_date or not (sticker.status == "current" or sticker.status == "to_be_returned"):
             raise serializers.ValidationError("cannot lose a sticker that has not yet been printed")
 
         # Update Sticker action
@@ -1487,7 +1487,7 @@ class StickerViewSet(viewsets.ModelViewSet):
         # data = request.data
         data = {}
 
-        if not sticker.printing_date or not (self.status == "current"):
+        if not sticker.printing_date or not (sticker.status == "current"):
             raise serializers.ValidationError("cannot replace a sticker that has not yet been printed")
 
         # Update Sticker action

--- a/mooringlicensing/components/approvals/models.py
+++ b/mooringlicensing/components/approvals/models.py
@@ -1657,6 +1657,10 @@ class AuthorisedUserPermit(Approval):
     def manage_stickers(self, proposal=None):
         logger.info(f'Managing stickers for the AuthorisedUserPermit: [{self}]...')
 
+        stickers_not_exported = self.approval.stickers.filter(status__in=[Sticker.STICKER_STATUS_NOT_READY_YET, Sticker.STICKER_STATUS_READY,])
+        if stickers_not_exported:
+            raise Exception('Cannot create a new sticker...  There is at least one sticker with ready/not_ready_yet status for the approval: [{self}].')
+
         # Lists to be returned to the caller
         moas_to_be_reallocated = []  # List of MooringOnApproval objects which are to be on the new stickers
         stickers_to_be_returned = []  # List of the stickers to be returned

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ djangorestframework-datatables~=0.7.0
 django-confy==1.0.4
 xlwt==1.3.0
 xlsxwriter~=3.2.0
-gunicorn==22.0.0
+gunicorn==23.0.0
 whitenoise==6.7.0
 mixer~=7.2.2
 django-dirtyfields==1.9.3


### PR DESCRIPTION
Adjustments to AUP amendment printing workflow to ensure proposals are not left in an invalid status and that the process can be complete for all scenarios.

Also, gunicorn upgrade.