### PR TITLE
MLA workflow and sticker process adjustments

### DIFF
--- a/mooringlicensing/components/approvals/api.py
+++ b/mooringlicensing/components/approvals/api.py
@@ -1437,7 +1437,7 @@ class StickerViewSet(viewsets.ModelViewSet):
         sticker = self.get_object()
         data = request.data
 
-        if not sticker.printing_date or not (self.status == "to_be_returned"):
+        if not sticker.printing_date or not (sticker.status == "to_be_returned"):
             raise serializers.ValidationError("cannot return a sticker that has not yet been printed")
 
         # Update Sticker action
@@ -1459,7 +1459,7 @@ class StickerViewSet(viewsets.ModelViewSet):
         sticker = self.get_object()
         data = request.data
 
-        if not sticker.printing_date or not (self.status == "current" or self.status == "to_be_returned"):
+        if not sticker.printing_date or not (sticker.status == "current" or sticker.status == "to_be_returned"):
             raise serializers.ValidationError("cannot lose a sticker that has not yet been printed")
 
         # Update Sticker action
@@ -1487,7 +1487,7 @@ class StickerViewSet(viewsets.ModelViewSet):
         # data = request.data
         data = {}
 
-        if not sticker.printing_date or not (self.status == "current"):
+        if not sticker.printing_date or not (sticker.status == "current"):
             raise serializers.ValidationError("cannot replace a sticker that has not yet been printed")
 
         # Update Sticker action

--- a/mooringlicensing/components/approvals/models.py
+++ b/mooringlicensing/components/approvals/models.py
@@ -2226,6 +2226,11 @@ class MooringLicence(Approval):
                 if not stickers_for_this_vessel or sticker_colour_to_be_changed:
                     # Sticker for this vessel not found OR new sticker colour is different from the existing sticker colour
                     # A new sticker should be created
+
+                    stickers_not_exported = self.approval.stickers.filter(status__in=[Sticker.STICKER_STATUS_NOT_READY_YET, Sticker.STICKER_STATUS_READY,])
+                    if stickers_not_exported:
+                        raise Exception('Cannot create a new sticker...  There is at least one sticker with ready/not_ready_yet status for the approval: [{self}].')
+            
                     new_sticker = Sticker.objects.create(
                         approval=self,
                         vessel_ownership=proposal.vessel_ownership,
@@ -2246,10 +2251,9 @@ class MooringLicence(Approval):
                 status__in=[
                     Sticker.STICKER_STATUS_CURRENT,
                     Sticker.STICKER_STATUS_AWAITING_PRINTING,
-                    Sticker.STICKER_STATUS_NOT_READY_YET,
-                    Sticker.STICKER_STATUS_READY,
                 ]
             )
+
             # CurrentStickers - StickersToBeKept = StickersToBeReturned
             stickers_to_be_returned = [sticker for sticker in stickers_current if sticker not in stickers_to_be_kept]
 
@@ -2286,6 +2290,10 @@ class MooringLicence(Approval):
                 if existing_sticker:
                     existing_sticker = existing_sticker.first()
                     stickers_to_be_replaced.append(existing_sticker)
+
+                stickers_not_exported = self.approval.stickers.filter(status__in=[Sticker.STICKER_STATUS_NOT_READY_YET, Sticker.STICKER_STATUS_READY,])
+                if stickers_not_exported:
+                    raise Exception('Cannot create a new sticker...  There is at least one sticker with ready/not_ready_yet status for the approval: [{self}].')
 
                 # Sticker not found --> Create it
                 new_sticker = Sticker.objects.create(

--- a/mooringlicensing/components/approvals/models.py
+++ b/mooringlicensing/components/approvals/models.py
@@ -816,9 +816,9 @@ class Approval(RevisionedMixin):
                 if type(self.child_obj) == AnnualAdmissionPermit:
                     customer_status_choices = [Proposal.CUSTOMER_STATUS_WITH_ASSESSOR, Proposal.CUSTOMER_STATUS_DRAFT, Proposal.CUSTOMER_STATUS_PRINTING_STICKER]
                 elif type(self.child_obj) == AuthorisedUserPermit:
-                    customer_status_choices = [Proposal.CUSTOMER_STATUS_WITH_ASSESSOR, Proposal.CUSTOMER_STATUS_DRAFT, Proposal.CUSTOMER_STATUS_AWAITING_ENDORSEMENT, Proposal.CUSTOMER_STATUS_PRINTING_STICKER, Proposal.CUSTOMER_STATUS_AWAITING_PAYMENT,]
+                    customer_status_choices = [Proposal.CUSTOMER_STATUS_WITH_ASSESSOR, Proposal.CUSTOMER_STATUS_DRAFT, Proposal.CUSTOMER_STATUS_AWAITING_ENDORSEMENT, Proposal.CUSTOMER_STATUS_AWAITING_PAYMENT,]
                 elif type(self.child_obj) == MooringLicence:
-                    customer_status_choices = [Proposal.CUSTOMER_STATUS_WITH_ASSESSOR, Proposal.CUSTOMER_STATUS_DRAFT, Proposal.CUSTOMER_STATUS_AWAITING_ENDORSEMENT, Proposal.CUSTOMER_STATUS_PRINTING_STICKER, Proposal.CUSTOMER_STATUS_AWAITING_PAYMENT, Proposal.CUSTOMER_STATUS_AWAITING_DOCUMENTS]
+                    customer_status_choices = [Proposal.CUSTOMER_STATUS_WITH_ASSESSOR, Proposal.CUSTOMER_STATUS_DRAFT, Proposal.CUSTOMER_STATUS_AWAITING_ENDORSEMENT, Proposal.CUSTOMER_STATUS_AWAITING_PAYMENT, Proposal.CUSTOMER_STATUS_AWAITING_DOCUMENTS]
             existing_proposal_qs=self.proposal_set.filter(customer_status__in=customer_status_choices,
                     proposal_type__in=ProposalType.objects.filter(code__in=[PROPOSAL_TYPE_AMENDMENT, PROPOSAL_TYPE_RENEWAL, PROPOSAL_TYPE_SWAP_MOORINGS,]))
             ## cannot amend or renew

--- a/mooringlicensing/components/approvals/models.py
+++ b/mooringlicensing/components/approvals/models.py
@@ -1657,6 +1657,10 @@ class AuthorisedUserPermit(Approval):
     def manage_stickers(self, proposal=None):
         logger.info(f'Managing stickers for the AuthorisedUserPermit: [{self}]...')
 
+        stickers_not_exported = self.approval.stickers.filter(status__in=[Sticker.STICKER_STATUS_NOT_READY_YET, Sticker.STICKER_STATUS_READY,])
+        if stickers_not_exported:
+            raise Exception('Cannot create a new sticker...  There is at least one sticker with ready/not_ready_yet status for the approval: [{self}].')
+
         # Lists to be returned to the caller
         moas_to_be_reallocated = []  # List of MooringOnApproval objects which are to be on the new stickers
         stickers_to_be_returned = []  # List of the stickers to be returned

--- a/mooringlicensing/components/approvals/models.py
+++ b/mooringlicensing/components/approvals/models.py
@@ -2218,6 +2218,8 @@ class MooringLicence(Approval):
                     status__in=[
                         Sticker.STICKER_STATUS_CURRENT,
                         Sticker.STICKER_STATUS_AWAITING_PRINTING,
+                        Sticker.STICKER_STATUS_NOT_READY_YET,
+                        Sticker.STICKER_STATUS_READY,
                     ],
                     vessel_ownership=vessel_ownership,
                 )
@@ -2244,6 +2246,8 @@ class MooringLicence(Approval):
                 status__in=[
                     Sticker.STICKER_STATUS_CURRENT,
                     Sticker.STICKER_STATUS_AWAITING_PRINTING,
+                    Sticker.STICKER_STATUS_NOT_READY_YET,
+                    Sticker.STICKER_STATUS_READY,
                 ]
             )
             # CurrentStickers - StickersToBeKept = StickersToBeReturned
@@ -2274,7 +2278,9 @@ class MooringLicence(Approval):
                     status__in=(
                         Sticker.STICKER_STATUS_CURRENT,
                         Sticker.STICKER_STATUS_AWAITING_PRINTING,
-                        Sticker.STICKER_STATUS_TO_BE_RETURNED,),
+                        Sticker.STICKER_STATUS_TO_BE_RETURNED,
+                        Sticker.STICKER_STATUS_NOT_READY_YET,
+                        Sticker.STICKER_STATUS_READY,),
                     vessel_ownership=vessel_ownership,
                 )
                 if existing_sticker:

--- a/mooringlicensing/components/proposals/api.py
+++ b/mooringlicensing/components/proposals/api.py
@@ -1660,7 +1660,6 @@ class ProposalViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
         instance = self.get_object()
 
         #TODO add auth check - internal or applicant (covered by get_queryset, but additional checks still warranted)
-
         approval = instance.approval
         ## validation
         renew_amend_conditions = {

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -1585,13 +1585,16 @@ class Proposal(DirtyFieldsMixin, RevisionedMixin):
                     try:
                         ria_mooring_name = Mooring.objects.get(id=mooring_id).name
                     except:
-                        raise serializers.ValidationError("Mooring id provided is invalid")
+                        if self.application_type.code == "aua":
+                            raise serializers.ValidationError("Mooring id provided is invalid")
                 elif not mooring_on_approval or mooring_on_approval == []:
-                    raise serializers.ValidationError("No mooring provided")
+                    if self.application_type.code == "aua":
+                        raise serializers.ValidationError("No mooring provided")
                 else:
                     #check if mooring on approval list has at least one checked value
                     if not True in checked_list:
-                        raise serializers.ValidationError("No mooring provided")
+                        if self.application_type.code == "aua":
+                            raise serializers.ValidationError("No mooring provided")
 
                 self.proposed_issuance_approval = {
                     'current_date': current_date.strftime('%d/%m/%Y'),  # start_date and expiry_date are determined when making payment or approved???
@@ -1861,13 +1864,16 @@ class Proposal(DirtyFieldsMixin, RevisionedMixin):
                         try:
                             ria_mooring_name = Mooring.objects.get(id=mooring_id).name
                         except:
-                            raise serializers.ValidationError("Mooring id provided is invalid")
+                            if self.application_type.code == "aua":
+                                raise serializers.ValidationError("Mooring id provided is invalid")
                     elif not mooring_on_approval or mooring_on_approval == []:
-                        raise serializers.ValidationError("No mooring provided")
+                        if self.application_type.code == "aua":
+                            raise serializers.ValidationError("No mooring provided")
                     else:
                         #check if mooring on approval list has at least one checked value
                         if not True in checked_list:
-                            raise serializers.ValidationError("No mooring provided")
+                            if self.application_type.code == "aua":
+                                raise serializers.ValidationError("No mooring provided")
 
                     self.proposed_issuance_approval = {
                         'mooring_bay_id': details.get('mooring_bay_id'),

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ djangorestframework-datatables~=0.7.0
 django-confy==1.0.4
 xlwt==1.3.0
 xlsxwriter~=3.2.0
-gunicorn==22.0.0
+gunicorn==23.0.0
 whitenoise==6.7.0
 mixer~=7.2.2
 django-dirtyfields==1.9.3


### PR DESCRIPTION
Number of changes to ensure proposal statuses are updated properly for MLAs.

Includes:
 - proper support for adding more vessels to a ML (before additional stickers were not being printed)
 - ensuring statuses are properly handled if a printer is still being printed (users can make amendments while stickers are still being printed)
 - allowing users to make multiple amendments while previous amendments are still printing sticker
 - ensuring proposals are not approvable (but can still be submitted) until existing sticker records are exported

Changes have been tested for amendments, additional testing/changes for renewals will need to be conducted later on. 