### PR TITLE
AUA endorsement workflow controls

### DIFF
--- a/mooringlicensing/components/proposals/api.py
+++ b/mooringlicensing/components/proposals/api.py
@@ -1756,13 +1756,13 @@ class ProposalViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
         serializer = serializer_class(instance,context={'request':request})
         return Response(serializer.data)
 
-    detail_route(methods=['POST',], detail=True)
+    @detail_route(methods=['POST',], detail=True)
     @basic_exception_handler
     def bypass_endorsement(self, request, *args, **kwargs):
         instance = self.get_object()
         if is_internal(request):
             #check if an AUA awaiting endorsement
-            if instance.application_type_code == 'aua' and instance.status == Proposal.PROCESSING_STATUS_AWAITING_ENDORSEMENT:
+            if instance.application_type_code == 'aua' and instance.processing_status == Proposal.PROCESSING_STATUS_AWAITING_ENDORSEMENT:
                 #run function to move to with_assessor (include auth check in model func)
                 instance.bypass_endorsement(request)
             else:
@@ -1774,13 +1774,13 @@ class ProposalViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
         else:
             serializers.ValidationError("User not authorised to bypass endorsement")
     
-    detail_route(methods=['POST',], detail=True)
+    @detail_route(methods=['POST',], detail=True)
     @basic_exception_handler
     def request_endorsement(self, request, *args, **kwargs):
         instance = self.get_object()
         if is_internal(request):
             #check if an AUA with site licensee mooring requests, that have not been actioned, with assessor
-            if instance.application_type_code == 'aua' and instance.status == Proposal.PROCESSING_STATUS_WITH_ASSESSOR:
+            if instance.application_type_code == 'aua' and instance.processing_status == Proposal.PROCESSING_STATUS_WITH_ASSESSOR:
                 if instance.site_licensee_mooring_request.filter(enabled=True,declined_by_endorser=False,approved_by_endorser=False).exists():
                     #run function to move to awaiting_endorsement (include auth check in model func)
                     instance.request_endorsement(request)

--- a/mooringlicensing/components/proposals/api.py
+++ b/mooringlicensing/components/proposals/api.py
@@ -1756,6 +1756,45 @@ class ProposalViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
         serializer = serializer_class(instance,context={'request':request})
         return Response(serializer.data)
 
+    detail_route(methods=['POST',], detail=True)
+    @basic_exception_handler
+    def bypass_endorsement(self, request, *args, **kwargs):
+        instance = self.get_object()
+        if is_internal(request):
+            #check if an AUA awaiting endorsement
+            if instance.application_type_code == 'aua' and instance.status == Proposal.PROCESSING_STATUS_AWAITING_ENDORSEMENT:
+                #run function to move to with_assessor (include auth check in model func)
+                instance.bypass_endorsement(request)
+            else:
+                serializers.ValidationError("Invalid application type")
+
+            serializer_class = self.internal_serializer_class()
+            serializer = serializer_class(instance,context={'request':request})
+            return Response(serializer.data)
+        else:
+            serializers.ValidationError("User not authorised to bypass endorsement")
+    
+    detail_route(methods=['POST',], detail=True)
+    @basic_exception_handler
+    def request_endorsement(self, request, *args, **kwargs):
+        instance = self.get_object()
+        if is_internal(request):
+            #check if an AUA with site licensee mooring requests, that have not been actioned, with assessor
+            if instance.application_type_code == 'aua' and instance.status == Proposal.PROCESSING_STATUS_WITH_ASSESSOR:
+                if instance.site_licensee_mooring_request.filter(enabled=True,declined_by_endorser=False,approved_by_endorser=False).exists():
+                    #run function to move to awaiting_endorsement (include auth check in model func)
+                    instance.request_endorsement(request)
+                else:
+                    serializers.ValidationError("No site licensee moorings requests that require action")
+            else:
+                serializers.ValidationError("Invalid application type")
+
+            serializer_class = self.internal_serializer_class()
+            serializer = serializer_class(instance,context={'request':request})
+            return Response(serializer.data)
+        else:
+            serializers.ValidationError("User not authorised to request endorsement")
+
     @detail_route(methods=['POST',], detail=True)
     @basic_exception_handler
     def reissue_approval(self, request, *args, **kwargs):

--- a/mooringlicensing/components/proposals/email.py
+++ b/mooringlicensing/components/proposals/email.py
@@ -1514,7 +1514,7 @@ def send_endorsement_of_authorised_user_application_email(request, proposal):
             'login_url': login_url,
         }
 
-        to_address = proposal.site_licensee_email
+        to_address = site_licensee_mooring_request.site_licensee_email
         cc = []
         bcc = []
 

--- a/mooringlicensing/components/proposals/email.py
+++ b/mooringlicensing/components/proposals/email.py
@@ -1479,7 +1479,7 @@ def send_sticker_printing_batch_email(batches):
 
     return msg
 
-
+#TODO refactor this
 def send_endorsement_of_authorised_user_application_email(request, proposal):
     email = TemplateEmailBase(
         subject='Endorsement of Authorised user application',

--- a/mooringlicensing/components/proposals/email.py
+++ b/mooringlicensing/components/proposals/email.py
@@ -1479,7 +1479,6 @@ def send_sticker_printing_batch_email(batches):
 
     return msg
 
-#TODO refactor this
 def send_endorsement_of_authorised_user_application_email(request, proposal):
     email = TemplateEmailBase(
         subject='Endorsement of Authorised user application',
@@ -1500,6 +1499,7 @@ def send_endorsement_of_authorised_user_application_email(request, proposal):
 
         #iterate through each site licensee mooring request
         mooring_name = site_licensee_mooring_request.mooring.name if site_licensee_mooring_request.mooring else ''
+        print(proposal)
         due_date = proposal.get_due_date_for_endorsement_by_target_date()
 
         # Configure recipients, contents, etc

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -1208,7 +1208,7 @@ class Proposal(DirtyFieldsMixin, RevisionedMixin):
         return self.child_obj.is_approver(user)
 
     def can_assess(self, user):
-        if self.processing_status in [Proposal.PROCESSING_STATUS_WITH_ASSESSOR, Proposal.PROCESSING_STATUS_WITH_ASSESSOR_REQUIREMENTS,Proposal.PROCESSING_STATUS_DRAFT]:
+        if self.processing_status in [Proposal.PROCESSING_STATUS_WITH_ASSESSOR, Proposal.PROCESSING_STATUS_WITH_ASSESSOR_REQUIREMENTS,Proposal.PROCESSING_STATUS_DRAFT,Proposal.PROCESSING_STATUS_AWAITING_ENDORSEMENT]:
             return self.child_obj.is_assessor(user)
         elif self.processing_status in [Proposal.PROCESSING_STATUS_WITH_APPROVER, Proposal.PROCESSING_STATUS_AWAITING_PAYMENT, Proposal.PROCESSING_STATUS_PRINTING_STICKER]:
             return self.child_obj.is_approver(user)
@@ -1416,7 +1416,7 @@ class Proposal(DirtyFieldsMixin, RevisionedMixin):
                     #run function to move to awaiting_endorsement (include auth check in model func)
                     self.processing_status = Proposal.PROCESSING_STATUS_AWAITING_ENDORSEMENT
                     self.save()
-                    send_endorsement_of_authorised_user_application_email(request, self)
+                    send_endorsement_of_authorised_user_application_email(request, self.child_obj)
                 else:
                     serializers.ValidationError("No site licensee moorings requests that require action")
             else:

--- a/mooringlicensing/components/proposals/serializers.py
+++ b/mooringlicensing/components/proposals/serializers.py
@@ -956,6 +956,7 @@ class InternalProposalSerializer(BaseProposalSerializer):
     vessel_on_proposal = serializers.SerializerMethodField()
     proposed_issuance_approval = serializers.SerializerMethodField()
     site_licensee_moorings = serializers.SerializerMethodField()
+    has_unactioned_endorsements = serializers.SerializerMethodField()
 
     class Meta:
         model = Proposal
@@ -1053,6 +1054,7 @@ class InternalProposalSerializer(BaseProposalSerializer):
                 'amendment_requests',
                 'uuid',
                 'allocated_mooring',
+                'has_unactioned_endorsements',
                 )
         read_only_fields = (
             'documents',
@@ -1290,6 +1292,9 @@ class InternalProposalSerializer(BaseProposalSerializer):
             'assessor_can_assess': obj.can_assess(user),
         }
     
+    def get_has_unactioned_endorsements(self,obj):
+        return obj.site_licensee_mooring_request.filter(enabled=True, declined_by_endorser=False, approved_by_endorser=False).exists()
+
     #TODO clean up auth check functions - remove redundant checks and rename to make more sense
     def get_approver_mode(self,obj):
         request = self.context['request']

--- a/mooringlicensing/components/proposals/serializers.py
+++ b/mooringlicensing/components/proposals/serializers.py
@@ -1070,7 +1070,7 @@ class InternalProposalSerializer(BaseProposalSerializer):
             checked = i.approved_by_endorser
             if obj.proposed_issuance_approval and 'requested_mooring_on_approval' in obj.proposed_issuance_approval:
                 for item in obj.proposed_issuance_approval['requested_mooring_on_approval']:
-                    if  i.id == item['id']:
+                    if  i.mooring_id == item['id']:
                         checked = item['checked']
 
             site_licensee = ""

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/workflow.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/workflow.vue
@@ -13,6 +13,7 @@
                             <div class="col-sm-12">
                                 <div class="separator"></div>
                             </div>
+                            
                             <div v-if="!isFinalised" class="col-sm-12 top-buffer-s">
                                 <strong>Currently assigned to</strong><br/>
                                 <div class="form-group">
@@ -135,6 +136,16 @@
                                     <div class="row" v-if="display_action_back_to_assessor">
                                         <div class="col-sm-12" v-if="proposal.proposed_decline_status">
 -->
+                                    <div class="row" v-if="display_bypass_endorsement">
+                                        <div class="col-sm-12">
+                                            <button 
+                                                class="btn btn-primary top-buffer-s w-btn" 
+                                                :disabled="can_user_edit" 
+                                                @click.prevent="bypassEndorsement()"
+                                            >Bypass Endorsement</button>
+                                        </div>
+                                    </div>
+
                                     <div class="row" v-if="display_action_back_to_assessor">
                                         <div class="col-sm-12">
                                             <button 
@@ -178,6 +189,15 @@
                                                 class="btn btn-primary top-buffer-s w-btn" 
                                                 @click.prevent="declineProposal()"
                                             >Decline</button><br/>
+                                        </div>
+                                    </div>
+
+                                    <div class="row" v-if="display_request_endorsement">
+                                        <div class="col-sm-12">
+                                            <button 
+                                                class="btn btn-primary top-buffer-s w-btn" 
+                                                @click.prevent="requestEndorsement()"
+                                            >Request Endorsement</button><br/>
                                         </div>
                                     </div>
 <!--
@@ -292,6 +312,29 @@ export default {
             } catch(err) {}
             return display
         },
+        display_bypass_endorsement: function(){
+            let display = false
+            try {
+                if([constants.AU_PROPOSAL].includes(this.proposal.application_type_dict.code)){
+                    if(this.proposal.processing_status === constants.AWAITING_ENDORSEMENT){
+                        display = true
+                    }
+                }
+            } catch(err) {}
+            return display
+        },
+        display_request_endorsement: function(){
+            let display = false
+            try {
+                if([constants.AU_PROPOSAL].includes(this.proposal.application_type_dict.code)){
+                    if(this.proposal.processing_status === constants.WITH_ASSESSOR && 
+                    this.proposal.has_unactioned_endorsements){
+                        display = true
+                    }
+                }
+            } catch(err) {}
+            return display
+        },
         display_action_back_to_assessor: function(){
             let display = false
             try {
@@ -347,6 +390,12 @@ export default {
         }
     },
     methods: {
+        bypassEndorsement: function(){
+            this.$emit('bypassEndorsement')
+        },
+        requestEndorsement: function(){
+            this.$emit('requestEndorsement')
+        },
         backToAssessorRequirements: function(){
             this.$emit('backToAssessorRequirements')
         },


### PR DESCRIPTION
Authorised User Applications awaiting endorsement can now be forwarded to the with assessor stage via a bypass endorsement action.

They can also be put back to awaiting endorsement by assessors if any remaining mooring requests have yet to be actioned by an endorser.

Currently approvers can still select/deselect mooring requests - something to be reviewed and potentially removed (alongside other similar controls).