### PR TITLE
Approver controls review

### DIFF
--- a/mooringlicensing/components/proposals/api.py
+++ b/mooringlicensing/components/proposals/api.py
@@ -1856,7 +1856,7 @@ class ProposalViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
     @basic_exception_handler
     def approval_level_document(self, request, *args, **kwargs):
         instance = self.get_object()
-        instance = instance.assing_approval_level_document(request)
+        instance = instance.assign_approval_level_document(request)
         serializer = InternalProposalSerializer(instance,context={'request':request})
         return Response(serializer.data)
 

--- a/mooringlicensing/components/proposals/utils.py
+++ b/mooringlicensing/components/proposals/utils.py
@@ -353,7 +353,6 @@ def save_proponent_data(instance, request, action, being_auto_approved=False):
          instance.proposal_applicant.email_user_id == request.user.id and 
          (instance.processing_status == Proposal.PROCESSING_STATUS_DRAFT) or being_auto_approved)
         or instance.has_assessor_mode(request.user)
-        or instance.has_approver_mode(request.user)
     ):
         if action == 'submit':
             logger.info('Proposal {} has been submitted'.format(instance.lodgement_number))
@@ -388,8 +387,7 @@ def save_proponent_data_aaa(instance, request, action):
     vessel_data = deepcopy(request.data.get("vessel"))
     if vessel_data:
         if ((action == 'submit' or (
-            (instance.has_assessor_mode(request.user)
-            or instance.has_approver_mode(request.user)) and 
+            instance.has_assessor_mode(request.user) and 
             instance.processing_status != Proposal.PROCESSING_STATUS_DRAFT))):
             submit_vessel_data(instance, request, vessel_data)
         else:
@@ -433,8 +431,7 @@ def save_proponent_data_wla(instance, request, action):
     vessel_data = deepcopy(request.data.get("vessel"))
     if vessel_data:
         if ((action == 'submit' or (
-            (instance.has_assessor_mode(request.user)
-            or instance.has_approver_mode(request.user)) and 
+            instance.has_assessor_mode(request.user) and 
             instance.processing_status != Proposal.PROCESSING_STATUS_DRAFT))):
             submit_vessel_data(instance, request, vessel_data)
         else:
@@ -473,8 +470,7 @@ def save_proponent_data_mla(instance, request, action):
     vessel_data = deepcopy(request.data.get("vessel"))
     if vessel_data:
         if ((action == 'submit' or (
-            (instance.has_assessor_mode(request.user)
-            or instance.has_approver_mode(request.user)) and 
+            instance.has_assessor_mode(request.user) and 
             instance.processing_status != Proposal.PROCESSING_STATUS_DRAFT))):
             submit_vessel_data(instance, request, vessel_data)
         else:
@@ -520,8 +516,7 @@ def save_proponent_data_aua(instance, request, action):
     vessel_data = deepcopy(request.data.get("vessel"))
     if vessel_data:
         if ((action == 'submit' or (
-            (instance.has_assessor_mode(request.user)
-            or instance.has_approver_mode(request.user)) and 
+            instance.has_assessor_mode(request.user) and 
             instance.processing_status != Proposal.PROCESSING_STATUS_DRAFT))):
             submit_vessel_data(instance, request, vessel_data)
         else:

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/mooring_authorisation.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/mooring_authorisation.vue
@@ -156,8 +156,7 @@ import draggable from 'vuedraggable';
                             links += `<a href='/internal/moorings/${full.mooring_id}/'  target="_blank" style="cursor: pointer;">View</a><br/>`;
                             links += `<a onclick="window.removeSiteLicenseeMooring('${full.mooring_id}')" style="cursor: pointer;">Remove</a><br/>`;
 
-                            if (vm.proposal.processing_status == "Awaiting Endorsement" || vm.proposal.processing_status == "With Assessor" || 
-                                vm.proposal.processing_status == "With Approver" && full.endorsement !== undefined) {
+                            if ((vm.proposal.processing_status == "Awaiting Endorsement" || vm.proposal.processing_status == "With Assessor" || vm.proposal.processing_status == "With Assessor (Requirements)") && full.endorsement !== undefined) {
                                 if (full.endorsement == "Not Actioned") {
                                     links += `<a onclick="window.internalEndorse('${full.id}')" style="cursor: pointer;">Endorse on Licensee Behalf</a><br/>`;
                                     links += `<a onclick="window.internalDecline('${full.id}')" style="cursor: pointer;">Decline on Licensee Behalf</a><br/>`;

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/mooring_authorisation.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/mooring_authorisation.vue
@@ -40,7 +40,7 @@
                         <!--input :readonly="readonly" class="form-control" type="text" placeholder="" id="mooring_site_id" v-model="mooringSiteId" required=""/-->
                     </div>
                 </div>
-                <div class="col-lg-2 pull-right">
+                <div class="col-lg-2 pull-right" v-if="!readonly">
                     <button @click.prevent="addSiteLicensee()" class="btn btn-primary">Add</button>
                 </div>
                 <div class="row form-group">
@@ -154,7 +154,9 @@ import draggable from 'vuedraggable';
                         'render': function(row, type, full){
                             let links = '';
                             links += `<a href='/internal/moorings/${full.mooring_id}/'  target="_blank" style="cursor: pointer;">View</a><br/>`;
-                            links += `<a onclick="window.removeSiteLicenseeMooring('${full.mooring_id}')" style="cursor: pointer;">Remove</a><br/>`;
+                            if (!vm.readonly) {
+                                links += `<a onclick="window.removeSiteLicenseeMooring('${full.mooring_id}')" style="cursor: pointer;">Remove</a><br/>`;
+                            }
 
                             if ((vm.proposal.processing_status == "Awaiting Endorsement" || vm.proposal.processing_status == "With Assessor" || vm.proposal.processing_status == "With Assessor (Requirements)") && full.endorsement !== undefined) {
                                 if (full.endorsement == "Not Actioned") {

--- a/mooringlicensing/frontend/mooringlicensing/src/components/internal/proposals/proposal.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/internal/proposals/proposal.vue
@@ -366,14 +366,13 @@ export default {
             return show;
         },
         readonly: function() {
-            if (this.proposal.assessor_mode.has_assessor_mode || this.proposal.approver_mode.has_approver_mode) {
+            if (this.proposal.assessor_mode.has_assessor_mode) {
                 return false
             }
             return true
         },
         submittable: function() {
-            if ((this.proposal.assessor_mode.has_assessor_mode || 
-                this.proposal.approver_mode.has_approver_mode) &&
+            if ((this.proposal.assessor_mode.has_assessor_mode) &&
                 (this.proposal.processing_status == 'Draft' || 
                 this.proposal.processing_status == 'Awaiting Payment')) {
                 return true

--- a/mooringlicensing/frontend/mooringlicensing/src/components/internal/proposals/proposed_issuance.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/internal/proposals/proposed_issuance.vue
@@ -20,7 +20,7 @@
                                     </div>
                                     <div class="col-sm-6">
                                         <select class="form-control" v-model="approval.mooring_bay_id"
-                                            id="mooring_bay_lookup">
+                                            id="mooring_bay_lookup" :disabled="readonly">
                                             <option v-for="bay in mooringBays" v-bind:value="bay.id">
                                                 {{ bay.name }}
                                             </option>
@@ -35,7 +35,7 @@
                                     </div>
                                     <div class="col-sm-6">
                                         <select id="mooring_lookup" name="mooring_lookup" ref="mooring_lookup"
-                                            class="form-control" style="width:100%" />
+                                            class="form-control" style="width:100%" :disabled="readonly"/>
                                     </div>
                                 </div>
                             </div>
@@ -92,19 +92,18 @@
                                     </div>
                                     <div class="col-sm-9">
                                         <textarea name="approval_details" class="form-control" style="width:70%;"
-                                            v-model="approval.details"></textarea>
+                                            v-model="approval.details" :readonly="readonly"></textarea>
                                     </div>
                                 </div>
                             </div>
                             <div class="form-group">
                                 <div class="row">
                                     <div class="col-sm-3">
-
                                         <label class="control-label pull-left" for="Name">{{ ccText }}</label>
                                     </div>
                                     <div class="col-sm-9">
                                         <input type="text" class="form-control" name="approval_cc" style="width:70%;"
-                                            ref="bcc_email" v-model="approval.cc_email">
+                                            ref="bcc_email" v-model="approval.cc_email" :readonly="readonly">
                                     </div>
                                 </div>
                             </div>
@@ -171,6 +170,10 @@ export default {
         },
         mooringBays: {
             type: Array,
+        },
+        readonly:{
+            type: Boolean,
+            default: true,
         },
     },
     data: function () {
@@ -257,10 +260,14 @@ export default {
                         //className: 'dt-body-center',
                         data: 'id',
                         mRender: function (data, type, full) {
+                            let disabled_str = ''
+                            if (vm.readonly) {
+                                disabled_str = ' disabled '
+                            }
                             if (full.checked) {
-                                return '<input type="checkbox" class="mooring_on_approval_checkbox" data-mooring-on-approval-id="' + full.id + '"' + ' checked/>'
+                                return '<input type="checkbox" class="mooring_on_approval_checkbox" data-mooring-on-approval-id="' + full.id + '"'  + disabled_str +  ' checked/>'
                             } else {
-                                return '<input type="checkbox" class="mooring_on_approval_checkbox" data-mooring-on-approval-id="' + full.id + '"' + '/>'
+                                return '<input type="checkbox" class="mooring_on_approval_checkbox" data-mooring-on-approval-id="' + full.id + '"'  + disabled_str +  '/>'
                             }
                             return '';
 
@@ -390,10 +397,14 @@ export default {
                         //className: 'dt-body-center',
                         data: 'id',
                         mRender: function (data, type, full) {
+                            let disabled_str = ''
+                            if (vm.readonly) {
+                                disabled_str = ' disabled '
+                            }
                             if (full.checked) {
-                                return '<input type="checkbox" class="requested_mooring_on_approval_checkbox" data-requested-mooring-on-approval-id="' + full.id + '"' + ' checked/>'
+                                return '<input type="checkbox" class="requested_mooring_on_approval_checkbox" data-requested-mooring-on-approval-id="' + full.id + '"'  + disabled_str +  ' checked/>'
                             } else {
-                                return '<input type="checkbox" class="requested_mooring_on_approval_checkbox" data-requested-mooring-on-approval-id="' + full.id + '"' + '/>'
+                                return '<input type="checkbox" class="requested_mooring_on_approval_checkbox" data-requested-mooring-on-approval-id="' + full.id + '"'  + disabled_str +  '/>'
                             }
                             return '';
 


### PR DESCRIPTION
After review and changes Approvers:

- can no longer edit an application (and an application cannot be edited once "with approver")
- change the requested moorings of an application
- endorse/decline mooring requests on an endorsers behalf

Assessors can still do all of the above while with the appropriate processing_status.

Approvers can still create applications on a user's behalf, but cannot modifying/submit the application after (which assessors can still do)