### PR TITLE
Realign Migration Script

### DIFF
--- a/mooringlicensing/components/proposals/api.py
+++ b/mooringlicensing/components/proposals/api.py
@@ -686,8 +686,9 @@ class ProposalPaginatedViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         request_user = self.request.user
-        #all = Proposal.objects.all()
-        all = Proposal.objects.exclude(migrated=True)
+        all = Proposal.objects.all()
+        #TODO do we need to exclude migrated proposals?
+        #all = Proposal.objects.exclude(migrated=True)
 
         target_email_user_id = int(self.request.GET.get('target_email_user_id', 0))
 
@@ -1204,7 +1205,9 @@ class ProposalViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
             queryset = Proposal.objects.filter(
                 Q(org_applicant_id__in=user_orgs) | 
                 Q(proposal_applicant__email_user_id=request_user.id)
-            ).exclude(migrated=True)
+            )
+            #TODO do we need to exclude migrated proposals?
+            #.exclude(migrated=True)
 
             # For the endoser to view the endosee's proposal
             if 'uuid' in self.request.query_params:

--- a/mooringlicensing/components/users/utils.py
+++ b/mooringlicensing/components/users/utils.py
@@ -7,6 +7,34 @@ from django.core.mail import EmailMultiAlternatives, EmailMessage
 from django.utils.encoding import smart_str
 
 from mooringlicensing.components.users.models import EmailUserLogEntry, private_storage
+from ledger_api_client.managed_models import SystemUser
+
+def create_system_user(email_user_id, email, first_name, last_name):
+    return SystemUser.objects.create(
+        ledger_id_id=email_user_id,
+        email=email,
+        first_name=first_name,
+        last_name=last_name,
+    )
+
+def get_or_create_system_user(email_user_id, email, first_name, last_name, update=False):
+    qs = SystemUser.objects.filter(ledger_id_id=email_user_id)
+    if qs.exists():
+        system_user = qs.first()
+        if update:            
+            system_user.email = email
+            system_user.first_name = first_name
+            system_user.last_name = last_name
+            system_user.save()
+        return system_user, False 
+    else:
+        system_user = SystemUser.objects.create(
+            ledger_id_id=email_user_id,
+            email=email,
+            first_name=first_name,
+            last_name=last_name,
+        )
+        return system_user, True
 
 def get_user_name(user):
     """

--- a/mooringlicensing/components/users/utils.py
+++ b/mooringlicensing/components/users/utils.py
@@ -9,15 +9,18 @@ from django.utils.encoding import smart_str
 from mooringlicensing.components.users.models import EmailUserLogEntry, private_storage
 from ledger_api_client.managed_models import SystemUser
 
-def create_system_user(email_user_id, email, first_name, last_name):
+def create_system_user(email_user_id, email, first_name, last_name, dob, phone=None, mobile=None):
     return SystemUser.objects.create(
         ledger_id_id=email_user_id,
         email=email,
         first_name=first_name,
         last_name=last_name,
+        legal_dob=dob,
+        phone_number=phone,
+        mobile_number=mobile,
     )
 
-def get_or_create_system_user(email_user_id, email, first_name, last_name, update=False):
+def get_or_create_system_user(email_user_id, email, first_name, last_name, dob, phone=None, mobile=None, update=False):
     qs = SystemUser.objects.filter(ledger_id_id=email_user_id)
     if qs.exists():
         system_user = qs.first()
@@ -25,6 +28,9 @@ def get_or_create_system_user(email_user_id, email, first_name, last_name, updat
             system_user.email = email
             system_user.first_name = first_name
             system_user.last_name = last_name
+            system_user.legal_dob = dob
+            system_user.phone_number = phone
+            system_user.mobile_number = mobile
             system_user.save()
         return system_user, False 
     else:
@@ -33,6 +39,9 @@ def get_or_create_system_user(email_user_id, email, first_name, last_name, updat
             email=email,
             first_name=first_name,
             last_name=last_name,
+            legal_dob=dob,
+            phone_number=phone,
+            mobile_number=mobile,
         )
         return system_user, True
 

--- a/mooringlicensing/components/users/utils.py
+++ b/mooringlicensing/components/users/utils.py
@@ -7,7 +7,7 @@ from django.core.mail import EmailMultiAlternatives, EmailMessage
 from django.utils.encoding import smart_str
 
 from mooringlicensing.components.users.models import EmailUserLogEntry, private_storage
-from ledger_api_client.managed_models import SystemUser
+from ledger_api_client.managed_models import SystemUser, SystemUserAddress
 
 def create_system_user(email_user_id, email, first_name, last_name, dob, phone=None, mobile=None):
     return SystemUser.objects.create(
@@ -19,6 +19,19 @@ def create_system_user(email_user_id, email, first_name, last_name, dob, phone=N
         phone_number=phone,
         mobile_number=mobile,
     )
+
+def get_or_create_system_user_address(system_user, system_address_dict, use_for_postal=False):
+    """
+        takes SystemUser object and SystemUserAddress dict, 
+        checks if a corresponding SystemUserAddress records exists, 
+        and create that SystemUserAddress record if it does not exist
+    """
+    qs = SystemUserAddress.objects.filter(system_user=system_user, **system_address_dict)
+    if not qs.exists():
+        SystemUserAddress.create(system_user=system_user, **system_address_dict, use_for_postal=use_for_postal)
+    elif use_for_postal and not qs.filter(use_for_postal=use_for_postal):
+        qs.update(use_for_postal=True)
+        
 
 def get_or_create_system_user(email_user_id, email, first_name, last_name, dob, phone=None, mobile=None, update=False):
     qs = SystemUser.objects.filter(ledger_id_id=email_user_id)

--- a/mooringlicensing/components/users/utils.py
+++ b/mooringlicensing/components/users/utils.py
@@ -28,7 +28,7 @@ def get_or_create_system_user_address(system_user, system_address_dict, use_for_
     """
     qs = SystemUserAddress.objects.filter(system_user=system_user, **system_address_dict)
     if not qs.exists():
-        SystemUserAddress.create(system_user=system_user, **system_address_dict, use_for_postal=use_for_postal)
+        SystemUserAddress.objects.create(system_user=system_user, **system_address_dict, use_for_postal=use_for_postal)
     elif use_for_postal and not qs.filter(use_for_postal=use_for_postal):
         qs.update(use_for_postal=True)
         

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/applicant.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/applicant.vue
@@ -40,15 +40,19 @@
                                 <div class="form-group">
                                     <label for="" class="col-sm-3 control-label">Legal Given Name(s)</label>
                                     <div class="col-sm-6">
-                                        <input disabled type="text" class="form-control" placeholder=""
+                                        <input v-if="user.legal_first_name" disabled type="text" class="form-control" placeholder=""
                                             v-model="user.legal_first_name">
+                                        <input v-else disabled type="text" class="form-control" placeholder=""
+                                            v-model="user.first_name">
                                     </div>
                                 </div>
                                 <div class="form-group">
                                     <label for="" class="col-sm-3 control-label">Legal Surname</label>
                                     <div class="col-sm-6">
-                                        <input disabled type="text" class="form-control" placeholder=""
+                                        <input v-if="user.legal_last_name" disabled type="text" class="form-control" placeholder=""
                                             v-model="user.legal_last_name">
+                                        <input v-else disabled type="text" class="form-control" placeholder=""
+                                            v-model="user.last_name">
                                     </div>
                                 </div>
 

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/table_proposals.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/table_proposals.vue
@@ -322,7 +322,11 @@ export default {
                 visible: true,
                 'render': function(row, type, full){
                     if (full.applicant){
-                        return `${full.applicant.legal_first_name} ${full.applicant.legal_last_name}`
+                        if (full.applicant.legal_first_name) {
+                            return `${full.applicant.legal_first_name} ${full.applicant.legal_last_name}`
+                        } else {
+                            return `${full.applicant.first_name} ${full.applicant.last_name}`
+                        }
                     }
                     return ''
                 },

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/vessels.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/vessels.vue
@@ -386,7 +386,11 @@ export default {
         },
         profileFullName: function () {
             if (this.profile) {
-                return this.profile.legal_first_name + ' ' + this.profile.legal_last_name;
+                if (this.profile.legal_first_name) {
+                    return this.profile.legal_first_name + ' ' + this.profile.legal_last_name;
+                } else {
+                    return this.profile.first_name + ' ' + this.profile.last_name;
+                }
             }
             return ''
         },

--- a/mooringlicensing/frontend/mooringlicensing/src/components/internal/proposals/proposal.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/internal/proposals/proposal.vue
@@ -15,9 +15,14 @@
                     :disable_add_entry="false"
                 />
 
-                <Submission v-if="canSeeSubmission"
+                <Submission v-if="canSeeSubmission && proposal.submitter.legal_first_name"
                     :submitter_first_name="proposal.submitter.legal_first_name"
                     :submitter_last_name="proposal.submitter.legal_last_name"
+                    :lodgement_date="proposal.lodgement_date"
+                />
+                <Submission v-else-if="canSeeSubmission"
+                    :submitter_first_name="proposal.submitter.first_name"
+                    :submitter_last_name="proposal.submitter.last_name"
                     :lodgement_date="proposal.lodgement_date"
                 />
 

--- a/mooringlicensing/frontend/mooringlicensing/src/components/user/profile.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/user/profile.vue
@@ -50,14 +50,20 @@
                       <form class="form-horizontal">
                         <div class="form-group">
                           <label for="" class="col-sm-3 control-label">Given name(s)</label>
-                          <div class="col-sm-6">
+                          <div class="col-sm-6" v-if="profile.legal_first_name">
                               <input readonly type="text" class="form-control" id="first_name" name="Given name" placeholder="" v-model="profile.legal_first_name" required="">
+                          </div>
+                          <div class="col-sm-6" v-else>
+                              <input readonly type="text" class="form-control" id="first_name" name="Given name" placeholder="" v-model="profile.first_name" required="">
                           </div>
                         </div>
                         <div class="form-group">
                           <label for="" class="col-sm-3 control-label" >Surname</label>
-                          <div class="col-sm-6">
+                          <div class="col-sm-6" v-if="profile.legal_first_name">
                               <input readonly type="text" class="form-control" id="surname" name="Surname" placeholder="" v-model="profile.legal_last_name">
+                          </div>
+                          <div class="col-sm-6" v-else>
+                              <input readonly type="text" class="form-control" id="first_name" name="Surname" placeholder="" v-model="profile.last_name" required="">
                           </div>
                         </div>
                         <div class="row form-group" v-if="!forEndorser">
@@ -460,7 +466,11 @@ export default {
         getApplicantDisplay: function () {           
             let vm = this; 
             console.log("getApplicantDisplay")
-            let display = vm.profile.legal_first_name + " " + vm.profile.legal_last_name + " (DOB: "+vm.profile.legal_dob+")";
+            if (vm.profile.legal_first_name) {
+                let display = vm.profile.legal_first_name + " " + vm.profile.legal_last_name + " (DOB: "+vm.profile.legal_dob+")";
+            } else {
+                let display = vm.profile.first_name + " " + vm.profile.last_name + " (DOB: "+vm.profile.legal_dob+")";
+            }
             var newOption = new Option(display, vm.profile.id, false, true);
             $('#person_lookup').append(newOption);         
         },

--- a/mooringlicensing/utils/mooring_licence_migrate_pd.py
+++ b/mooringlicensing/utils/mooring_licence_migrate_pd.py
@@ -737,7 +737,7 @@ class MooringLicenceReader():
                 self.pers_ids.append((user_id, row.name))
 
             except Exception as e:
-                self.user_error_details.append(row.name + " - " + user_row.email+" : "+str(e))
+                self.user_error_details.append(str(row.name) + " - " + str(user_row.email) + " : "+str(e))
                 self.user_errors.append(user_row.email)
                 logger.error(f'user: {row.name}   *********** 1 *********** FAILED. {e}')
 
@@ -759,6 +759,8 @@ class MooringLicenceReader():
             try:
                 #user_row = self.df_user[self.df_user['pers_no']==row.name] #.squeeze() # as Pandas Series
                 user_row = row.copy()
+
+                #TODO no email col?
 
                 email = user_row.email.lower().replace(' ','')
                 if not email:
@@ -798,9 +800,11 @@ class MooringLicenceReader():
                 self.pers_ids.append((user_id, row.name))
 
             except Exception as e:
-                self.user_error_details.append(row.name + " - " + user_row.email+" : "+str(e))
-                self.user_errors.append(user_row.email)
-                logger.error(f'user: {row.name}   *********** 1 *********** FAILED. {e}')
+                if hasattr(user_row, "email"):
+                    self.user_error_details.append(str(row.name) + " - " + str(user_row.email) + " : "+str(e))
+                    self.user_errors.append(user_row.email)
+                else:
+                    self.user_error_details.append(str(row.name)+" : "+str(e))
 
         print(f'users created:  {len(self.user_created)}')
         print(f'users existing: {len(self.user_existing)}')

--- a/mooringlicensing/utils/mooring_licence_migrate_pd.py
+++ b/mooringlicensing/utils/mooring_licence_migrate_pd.py
@@ -230,7 +230,7 @@ AA_COLUMN_MAPPING = {
 }
 
 
-
+#TODO review, remove if not needed
 def get_user_as_email_user(sender):
     try:
         sender_user = EmailUser.objects.get(email__icontains=sender)
@@ -294,6 +294,7 @@ class MooringLicenceReader():
         AnnualAdmissionApplication.objects.all().delete()
         ------
 
+        Sticker.objects.all().delete()
         Approval.objects.all().delete()
         Proposal.objects.all().delete()
         Vessel.objects.all().delete()
@@ -351,10 +352,6 @@ class MooringLicenceReader():
             row.home_number.replace(' ', '')
             return row.home_number
 
-    def __get_work_number(self, row):
-        return row.work_number.replace(' ', '')
-
-
     def __get_mobile_number(self, row):
         return row.mobile_number.replace(' ', '')
 
@@ -366,14 +363,13 @@ class MooringLicenceReader():
         #         country=Country.objects.get(iso_3166_1_a2='AU')
         #     return country.code
 
-
         # Rename the cols from Spreadsheet headers to Model fields names
         df_user = self.df_user.rename(columns=USER_COLUMN_MAPPING)
         df_user[df_user.columns] = df_user.apply(lambda x: x.str.strip() if isinstance(x, str) else x)
  
         # clean everything else
         df_user.fillna('', inplace=True)
-        df_user.replace({np.NaN: ''}, inplace=True)
+        df_user.replace({np.nan: ''}, inplace=True)
 
         #return df[:500]
         return df_user
@@ -386,7 +382,7 @@ class MooringLicenceReader():
  
         # clean everything else
         df_ml.fillna('', inplace=True)
-        df_ml.replace({np.NaN: ''}, inplace=True)
+        df_ml.replace({np.nan: ''}, inplace=True)
 
         # filter cancelled and rows with no name
         df_ml = df_ml[(df_ml['cancelled']=='N') & (df_ml['first_name_l'].isna()==False)]
@@ -398,7 +394,7 @@ class MooringLicenceReader():
 
         # clean everything else
         self.df_ves.fillna('', inplace=True)
-        self.df_ves.replace({np.NaN: ''}, inplace=True)
+        self.df_ves.replace({np.nan: ''}, inplace=True)
 
         # filter cancelled and rows with no name
         #df_ml = df_ml[(df_ml['cancelled']=='N') & (df_ml['first_name_l'].isna()==False)]
@@ -415,7 +411,7 @@ class MooringLicenceReader():
  
         # clean everything else
         df_authuser.fillna('', inplace=True)
-        df_authuser.replace({np.NaN: ''}, inplace=True)
+        df_authuser.replace({np.nan: ''}, inplace=True)
 
         # filter cancelled and rows with no name
         df_authuser = df_authuser[(df_authuser['cancelled']=='N')]
@@ -433,7 +429,7 @@ class MooringLicenceReader():
  
         # clean everything else
         df_wl.fillna('', inplace=True)
-        df_wl.replace({np.NaN: ''}, inplace=True)
+        df_wl.replace({np.nan: ''}, inplace=True)
 
         # filter cancelled and rows with no name
         df_wl = df_wl[(df_wl['app_status']=='W')]
@@ -462,7 +458,7 @@ class MooringLicenceReader():
  
         # clean everything else
         df_aa.fillna('', inplace=True)
-        df_aa.replace({np.NaN: ''}, inplace=True)
+        df_aa.replace({np.nan: ''}, inplace=True)
 
         # create dict of vessel details by rego_no --> self.vessels_dict['DO904']
         logger.info('Creating Vessels details Dictionary ...')
@@ -480,6 +476,7 @@ class MooringLicenceReader():
         self.create_dcv()
         self.create_annual_admissions()
 
+    #TODO remove
     def _run_migration(self):
 
         # create the users and organisations, if they don't already exist
@@ -2013,6 +2010,7 @@ class MooringLicenceReader():
         print(f'Vessel Details Not Found: {len(vessel_details_not_found)}')
 
 
+    #TODO remove
     def _migrate_approval(self, data, submitter, applicant=None, proxy_applicant=None):
         from disturbance.components.approvals.models import Approval
         #import ipdb; ipdb.set_trace()
@@ -2154,21 +2152,8 @@ class MooringLicenceReader():
 
         return approval
 
-#    def create_licence_pdf(self):
-#        approvals_migrated = Approval.objects.filter(migrated=True)
-#        print('Total Approvals: {} - {}'.format(approvals_migrated.count(), approvals_migrated))
-#        for idx, a in enumerate(approvals_migrated):
-#            a.generate_doc()
-#            print('{}, Created PDF for Approval {}'.format(idx, a))
-#
-#    def create_dcv_licence_pdf(self):
-#        approvals_migrated = DcvPermit.objects.filter(migrated=True)
-#        print('Total DCV Approvals: {} - {}'.format(approvals_migrated.count(), approvals_migrated))
-#        for idx, a in enumerate(approvals_migrated):
-#            a.generate_dcv_permit_doc()
-#            print('{}, Created PDF for DCV Approval {}'.format(idx, a))
 
-
+    #TODO include in run_migration?
     def create_licence_pdfs(self):
         MooringLicenceReader.create_pdf_ml()
         MooringLicenceReader.create_pdf_aup()
@@ -2228,12 +2213,13 @@ class MooringLicenceReader():
             except Exception as e:
                 logger.error(e)
 
-
+#TODO fix or replace - call from run_migration?
 def create_invoice(proposal, payment_method='other'):
         """
         This will create and invoice and order from a basket bypassing the session
         and payment bpoint code constraints.
         """
+        #TODO replace
         from ledger.checkout.utils import createCustomBasket
         from ledger.payments.invoice.utils import CreateInvoiceBasket
         from ledger.accounts.models import EmailUser
@@ -2256,7 +2242,7 @@ def create_invoice(proposal, payment_method='other'):
 
         return order
     
-
+#TODO review and/or remove
 def write_proposal_applicants(filename, path='/tmp/'):
     qs=ProposalApplicant.objects.all().values('email','first_name', 'last_name', 'dob', 'phone_number', 'mobile_number').distinct('email')
 
@@ -2265,6 +2251,3 @@ def write_proposal_applicants(filename, path='/tmp/'):
         write.writerow(['email','first_name','last_name','dob', 'phone_number', 'mobile_number'])
         for i in qs:
             write.writerows([i.values()])
-
-
-

--- a/mooringlicensing/utils/mooring_licence_migrate_pd.py
+++ b/mooringlicensing/utils/mooring_licence_migrate_pd.py
@@ -713,6 +713,7 @@ class MooringLicenceReader():
                 else:
                     logger.error(f'User creation failed: {email}')
                     self.user_errors.append(user_row.email)
+                    self.user_error_details.append(row.name + " - " + user_row.email+" : Ledger Response: " + str(resp))
 
                 self.pers_ids.append((user_id, row.name))
 
@@ -729,6 +730,8 @@ class MooringLicenceReader():
         print(f'no_email errors:   {len(self.no_email)}')
         print(f'users errors:   {self.user_errors}')
         print(f'no_email errors:   {self.no_email}')
+        for i in self.user_error_details:
+            print(i)
 
     def _create_users_df_aa(self, df):
         """ Reads the annual_admissions file created from the Mooring Booking System """
@@ -770,6 +773,7 @@ class MooringLicenceReader():
                 else:
                     logger.error(f'User creation failed: {email}')
                     self.user_errors.append(user_row.email)
+                    self.user_error_details.append(row.name + " - " + user_row.email+" : Ledger Response: " + str(resp))
 
                 user_id = resp['data']['emailuser_id']
                 self.pers_ids.append((user_id, row.name))
@@ -787,6 +791,8 @@ class MooringLicenceReader():
         print(f'no_email errors:   {len(self.no_email)}')
         print(f'users errors:   {self.user_errors}')
         print(f'no_email errors:   {self.no_email}')
+        for i in self.user_error_details:
+            print(i)
 
     def create_vessels(self):
         self._create_vessels()

--- a/mooringlicensing/utils/mooring_licence_migrate_pd.py
+++ b/mooringlicensing/utils/mooring_licence_migrate_pd.py
@@ -261,11 +261,16 @@ class MooringLicenceReader():
 
         mlr.create_users()
         mlr.create_vessels()
-        mlr.create_vessels_wl()
         mlr.create_mooring_licences()
         mlr.create_authuser_permits()
         mlr.create_waiting_list()
         mlr.create_dcv()
+
+        mlr.create_pdf_ml()
+        mlr.create_pdf_aup()
+        mlr.create_pdf_wl()
+        mlr.create_pdf_aa()
+        mlr.create_pdf_dcv()
 
     OR
         from mooringlicensing.utils.mooring_licence_migrate_pd import MooringLicenceReader
@@ -296,7 +301,9 @@ class MooringLicenceReader():
 
         Sticker.objects.all().delete()
         Approval.objects.all().delete()
+        ApprovalHistory.objects.all().delete()
         Proposal.objects.all().delete()
+        ProposalApplicant.objects.all().delete()
         Vessel.objects.all().delete()
         Owner.objects.all().delete()
         Mooring.objects.all().delete()
@@ -549,9 +556,10 @@ class MooringLicenceReader():
            mobile_number=mobile,
 
            email=user.email,
+           email_user_id=user.id,
         )
 
-        residential_address_dict, postal_address_dict, use_for_postal = self.create_system_user_address_dict(system_user, proposal_applicant)
+        residential_address_dict, postal_address_dict, use_for_postal = self.create_system_user_address_dict(proposal_applicant)
         get_or_create_system_user_address(system_user,residential_address_dict)
         if use_for_postal:
             get_or_create_system_user_address(system_user,postal_address_dict)
@@ -604,7 +612,7 @@ class MooringLicenceReader():
            email=user.email,
         )
 
-        residential_address_dict, postal_address_dict, use_for_postal = self.create_system_user_address_dict(system_user, proposal_applicant)
+        residential_address_dict, postal_address_dict, use_for_postal = self.create_system_user_address_dict(proposal_applicant)
         get_or_create_system_user_address(system_user,residential_address_dict)
         if use_for_postal:
             get_or_create_system_user_address(system_user,postal_address_dict)
@@ -1349,7 +1357,6 @@ class MooringLicenceReader():
 
             except Exception as e:
                 logger.error(f'ERROR: {row.name}. {str(e)}')
-                import ipdb; ipdb.set_trace()
                 self.user_errors.append(user_row.email)
 
         print(f'ml_user_not_found:  {self.ml_user_not_found}')

--- a/mooringlicensing/utils/mooring_licence_migrate_pd.py
+++ b/mooringlicensing/utils/mooring_licence_migrate_pd.py
@@ -506,7 +506,6 @@ class MooringLicenceReader():
             self.create_licence_pdf()
         except Exception as e:
             print(e)
-            import ipdb; ipdb.set_trace()
         t2_end = time.time()
         print('TIME TAKEN (Create License PDFs): {}'.format(t2_end - t2_start))
 
@@ -846,9 +845,6 @@ class MooringLicenceReader():
             return ves_details
 
         def try_except(value):
-            #if pers_no=='213162':
-            #    import ipdb; ipdb.set_trace()
-
             try:
                 val = float(value)
             except Exception:
@@ -860,9 +856,6 @@ class MooringLicenceReader():
         postfix = ['Nominated Ves', 'Ad Ves 2', 'Ad Ves 3', 'Ad Ves 4', 'Ad Ves 5', 'Ad Ves 6', 'Ad Ves 7']
         for user_id, pers_no in tqdm(self.pers_ids):
             try:
-                #if pers_no=='202600':
-                #    import ipdb; ipdb.set_trace()
-
                 ves_rows = self.df_ves[self.df_ves['Person No']==pers_no]
                 if len(ves_rows) > 1:
                     ves_rows = ves_rows[(ves_rows['Au Sticker No Nominated Ves']!='')]
@@ -893,11 +886,6 @@ class MooringLicenceReader():
                         au_sticker=ves['Au Sticker No ' + postfix[i]]
                         c_sticker=ves['C Sticker No ' + postfix[i]]
                         au_sticker_date=ves['Date Au Sticker Sent ' + postfix[i]]
-
-#                        if rego_no in ['DY167', '81900']:
-#                            import ipdb; ipdb.set_trace()
-#                        else:
-#                            continue
 
                         try:
                             ves_type = VESSEL_TYPE_MAPPING[ves_type]
@@ -939,8 +927,6 @@ class MooringLicenceReader():
                         #au_vessels.update({rego_no:au_sticker, sticker_sent:})
                         self.vessels_au.update({rego_no: dict(au_sticker=au_sticker, au_sticker_sent=au_sticker_date)})
                         c_vessels.append((rego_no, c_sticker))
-                        #if pers_no=='200700':
-                        #    import ipdb; ipdb.set_trace()
 
                     #self.vessels_au.update({pers_no:au_vessels})
                     self.vessels_dcv.update({pers_no:c_vessels})
@@ -970,9 +956,6 @@ class MooringLicenceReader():
                 return False
 
         def try_except(value):
-            #if pers_no=='213162':
-            #    import ipdb; ipdb.set_trace()
-
             try:
                 val = float(value)
             except Exception:
@@ -985,11 +968,6 @@ class MooringLicenceReader():
         df_wl = self.df_wl.groupby('vessel_rego').first()
         for index, row in tqdm(df_wl.iterrows(), total=df_wl.shape[0]):
             try:
-#                if row.pers_no=='088452':
-#                    import ipdb; ipdb.set_trace()
-#                else:
-#                    continue
-
                 rego_no = row.name
                 if is_invalid_rego(rego_no):
                     # User is on waiting list without a vessel - assign a dummy vessel
@@ -1007,17 +985,10 @@ class MooringLicenceReader():
                     user_row = user_row[:1]
                 user_row = user_row.squeeze() # convert to Pandas Series
 
-                #if not user_row.empty and user_row.pers_no=='000036':
-                #    import ipdb; ipdb.set_trace()
-
                 email = user_row.email.lower().replace(' ','')
                 if not email:
                     self.no_email.append(user_row.pers_no)
                     continue
-
-#                if email != 'ftroop351@gmail.com':
-#                    #import ipdb; ipdb.set_trace()
-#                    continue
 
                 users = EmailUser.objects.filter(email=email)
                 if users.count() == 0:
@@ -1109,9 +1080,6 @@ class MooringLicenceReader():
                     c_sticker=ves['C Sticker No ' + postfix[i]]
                     au_sticker_date=ves['Date Au Sticker Sent ' + postfix[i]]
 
-                    #if rego_no=='DO904':
-                    #    import ipdb; ipdb.set_trace()
-
                     self.vessels_dict.update({rego_no:
                         {
                             'length':        tot_length,
@@ -1132,9 +1100,6 @@ class MooringLicenceReader():
                     print(f'ERROR: vessels_dict: {str(e)}')
                     if e.args[0]=='Name Ad Ves 2':
                         continue
-                    else:
-                        import ipdb; ipdb.set_trace()
-                        pass
                     
 
 
@@ -1391,11 +1356,6 @@ class MooringLicenceReader():
             try:
 
                 rego_no = row.name
-                    
-                #TODO remove as a debug?
-                #if row.mooring_no == 'TB999':
-                #    # exclude mooring
-                #    continue
                 
                 mooring_authorisation_preference = 'site_licensee' if row['licencee_approved']=='Y' else 'ria'
                 mooring = Mooring.objects.filter(name=row['mooring_no'])[0]
@@ -1419,6 +1379,7 @@ class MooringLicenceReader():
 
                 rego_no = row.name
                 sticker_info = self.vessels_au.get(rego_no)
+                sticker_number = None
                 if sticker_info:
                     sticker_number = sticker_info['au_sticker']
                     sticker_sent = sticker_info['au_sticker_sent']
@@ -1474,7 +1435,7 @@ class MooringLicenceReader():
                 )
 
                 #add site_licensee_mooring_request - we assume all migrated endorsements have been approved
-                ProposalSiteLicenseeMooringRequest.create(
+                ProposalSiteLicenseeMooringRequest.objects.create(
                     proposal=proposal,
                     site_licensee_email=licensee.email,
                     mooring=mooring,
@@ -1482,11 +1443,10 @@ class MooringLicenceReader():
                     approved_by_endorser=True,
                 )
 
-                #import ipdb; ipdb.set_trace()
                 try:
                     user_row = self.df_user[self.df_user['pers_no']==row.pers_no_u].squeeze() # as Pandas Series
                 except Exception as e:
-                    import ipdb; ipdb.set_trace()
+                    print(e)
                 
                 proposal_applicant=self.create_proposal_applicant(proposal, user, user_row)
 
@@ -1567,19 +1527,17 @@ class MooringLicenceReader():
                         site_licensee=False,
                     )
 
-                #approval.generate_doc()
-
             except Exception as e:
+                print(e)
                 errors.append(str(e))
-                import ipdb; ipdb.set_trace()
-                pass
-                #raise Exception(str(e))
 
         print(f'vessel_not_found: {vessel_not_found}')
         print(f'vessel_not_found: {len(vessel_not_found)}')
         print(f'aup_created: {len(aup_created)}')
         print(f'au_stickers: au_stickers, {len(au_stickers)}')
         print(f'no_au_stickers: no_au_stickers, {len(no_au_stickers)}')
+        for i in errors:
+            print(i)
 
     def create_waiting_list(self):
         expiry_date = EXPIRY_DATE

--- a/mooringlicensing/utils/mooring_licence_migrate_pd.py
+++ b/mooringlicensing/utils/mooring_licence_migrate_pd.py
@@ -825,9 +825,8 @@ class MooringLicenceReader():
                         except ObjectDoesNotExist:
                             vessel = Vessel.objects.create(rego_no=rego_no)
 
-                        try:
-                            vessel_ownership = VesselOwnership.objects.filter(owner=owner, vessel=vessel).order_by("-created").first()
-                        except ObjectDoesNotExist:
+                        vessel_ownership = VesselOwnership.objects.filter(owner=owner, vessel=vessel).order_by("-created").first()
+                        if not vessel_ownership:
                             pct_interest = int(round(float(try_except(pct_interest)),0))
                             if pct_interest < 25:
                                 self.pct_interest_errors.append((pers_no, rego_no, pct_interest))
@@ -1103,11 +1102,11 @@ class MooringLicenceReader():
                     vessel_not_found.append(rego_no)
                     continue
 
-                try:
-                    vessel_ownership = VesselOwnership.objects.filter(owner=owner, vessel=vessel).order_by("-created").first()
-                except Exception as e:
+                vessel_ownership = VesselOwnership.objects.filter(owner=owner, vessel=vessel).order_by("-created").first()
+                if not vessel_ownership:
                     vessel_ownership_not_found.append(rego_no)
                     continue
+                
                 try:
                     vessel_details = VesselDetails.objects.get(vessel=vessel)
                 except MultipleObjectsReturned:
@@ -2094,11 +2093,11 @@ class MooringLicenceReader():
         return approval
 
     def create_licence_pdfs(self):
-        MooringLicenceReader.create_pdf_ml()
-        MooringLicenceReader.create_pdf_aup()
-        MooringLicenceReader.create_pdf_wl()
-        MooringLicenceReader.create_pdf_aa()
-        MooringLicenceReader.create_pdf_dcv()
+        self.create_pdf_ml()
+        self.create_pdf_aup()
+        self.create_pdf_wl()
+        self.create_pdf_aa()
+        self.create_pdf_dcv()
     
     @classmethod
     def create_pdf_ml(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ phonenumbers~=8.13.42
 #django-multiselectfield==0.1.12
 #django-smart-selects==1.5.9
 git+https://github.com/jazzband/django-smart-selects.git@1.7.1
-pandas~=2.2.2
+pandas~=2.2.3
 git+https://github.com/dbca-wa/django-media-serv.git#egg=django_media_serv
 django-widget-tweaks~=1.5.0
 django-phonenumber-field==8.0.0
@@ -62,7 +62,7 @@ tqdm~=4.66.5
 python-decouple==3.8
 git+https://github.com/dbca-wa/appmonitor_client.git#egg=appmonitor_client
 click==8.1.7
-numpy~=2.0.1
+numpy~=2.1.1
 setuptools~=72.1.0
 wheel==0.44.0
 git+https://github.com/dbca-wa/django5-utils-six.git#egg=django5_six


### PR DESCRIPTION
Changes to migration script for mooring licensing to account for:

- System User accounts and related required changes
- Inclusion of sticker addresses
- Adjustments to AUA that allow multiple moorings on a single application

System user accounts are now created alongside new and existing ledger accounts. 

System user addresses are added to their respective user accounts, while their ledger account addresses are no longer updated.

Creation of proposal applicant records have been adjusted to account for the related system user changes.

All instances of sticker creation have been adapted to include the postal address of their respective applicant.

Migration script now creates an instance of the site licensee mooring request model per the AUA changes allowing for multiple moorings - note migration still only creates a single instance per application.ml.

Number of errors have also been fixed related to other model changes, module updates, or leftover artifacts.

Number of remaining changes/fixes will need to be made RE:
- handling application fees for allowing renewals of migrated licenses
- handling approval history (disabled for most migrations currently)
- handling any other potential discrepancies that may be present with migrated records (tbd)
- changing EmailUser queries to use iexact (once fixed on ledger for consistency)
