### PR TITLE
Env var for fee item rounding

### DIFF
--- a/mooringlicensing/components/payments_ml/utils.py
+++ b/mooringlicensing/components/payments_ml/utils.py
@@ -108,10 +108,10 @@ def generate_line_item(application_type, fee_amount_adjusted, fee_constructor, i
             target_datetime_str,
         )
     
-    if settings.DEBUG:
-        # In debug environment, we want to avoid decimal number which may cuase some kind of error.
-        total_amount = math.ceil(float(fee_amount_adjusted))
-        total_amount_excl_tax = math.ceil(float(calculate_excl_gst(fee_amount_adjusted))) if fee_constructor.incur_gst else math.ceil(float(fee_amount_adjusted))
+    if settings.ROUND_FEE_ITEMS:
+        # In debug environment, we want to avoid decimal number which may cause some kind of error.
+        total_amount = round(float(fee_amount_adjusted))
+        total_amount_excl_tax = round(float(calculate_excl_gst(fee_amount_adjusted))) if fee_constructor.incur_gst else round(float(fee_amount_adjusted))
     else:
         total_amount = float(fee_amount_adjusted)
         total_amount_excl_tax = float(calculate_excl_gst(fee_amount_adjusted)) if fee_constructor.incur_gst else float(fee_amount_adjusted)

--- a/mooringlicensing/settings.py
+++ b/mooringlicensing/settings.py
@@ -20,6 +20,9 @@ DISABLE_EMAIL = env('DISABLE_EMAIL', False)
 SHOW_TESTS_URL = env('SHOW_TESTS_URL', False)
 SHOW_DEBUG_TOOLBAR = env('SHOW_DEBUG_TOOLBAR', False)
 
+#Settings for rounding application fee items
+ROUND_FEE_ITEMS = env('ROUND_FEE_ITEMS', False)
+
 if SHOW_DEBUG_TOOLBAR:
 
     def show_toolbar(request):


### PR DESCRIPTION
Before fee items would be rounded only in debug mode - also they wouldn't have an actual round operation applied, but a ceiling operation (i.e. always rounding up, no matter the value).

Now fee items will be rounded based on their own env var ROUND_FEE_ITEMS (bool) and they use the actual round operation (>=.5 rounded up, <.5 rounded down)