### PR TITLE
Email query update

### DIFF
--- a/mooringlicensing/components/approvals/api.py
+++ b/mooringlicensing/components/approvals/api.py
@@ -756,7 +756,6 @@ class ApprovalViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
 class DcvAdmissionViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
     queryset = DcvAdmission.objects.all().order_by('id')
     serializer_class = DcvAdmissionSerializer
-    permission_classes=[IsAuthenticated]
 
     def get_queryset(self):
         user = self.request.user
@@ -835,7 +834,7 @@ class DcvAdmissionViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
                 if email_address and email_address_confirmation:
                     if email_address == email_address_confirmation:
                         if skipper:
-                            this_user = EmailUser.objects.filter(email=email_address)
+                            this_user = EmailUser.objects.filter(email__iexact=email_address)
                             if this_user:
                                 new_user = this_user.first()
                             else:
@@ -962,7 +961,7 @@ class InternalDcvAdmissionViewSet(viewsets.GenericViewSet, mixins.RetrieveModelM
             if email_address and email_address_confirmation:
                 if email_address == email_address_confirmation:
                     if skipper:
-                        this_user = EmailUser.objects.filter(email=email_address)
+                        this_user = EmailUser.objects.filter(email__iexact=email_address)
                         if this_user:
                             new_user = this_user.first()
                         else:

--- a/mooringlicensing/components/proposals/email.py
+++ b/mooringlicensing/components/proposals/email.py
@@ -512,7 +512,7 @@ def send_endorser_reminder_email(proposal, request=None):
     msgs = []
     for site_licensee_mooring in proposal.site_licensee_mooring_request.filter(enabled=True,endorser_reminder_sent=False):
         try:
-            endorser = EmailUser.objects.get(email=site_licensee_mooring.site_licensee_email)
+            endorser = EmailUser.objects.get(email__iexact=site_licensee_mooring.site_licensee_email)
         except:
             # Should not reach here
             continue
@@ -1432,7 +1432,7 @@ def send_endorsement_of_authorised_user_application_email(request, proposal):
     for site_licensee_mooring_request in proposal.site_licensee_mooring_request.filter(enabled=True,declined_by_endorser=False,approved_by_endorser=False):
         #replace with multiple site licensee emails
         try:
-            endorser = EmailUser.objects.get(email=site_licensee_mooring_request.site_licensee_email)
+            endorser = EmailUser.objects.get(email__iexact=site_licensee_mooring_request.site_licensee_email)
         except:
             # Should not reach here
             return

--- a/mooringlicensing/components/proposals/serializers.py
+++ b/mooringlicensing/components/proposals/serializers.py
@@ -986,7 +986,7 @@ class InternalProposalSerializer(BaseProposalSerializer):
                         checked = item['checked']
 
             site_licensee = ""
-            site_licensee_system_user = su_qs.filter(email=i.site_licensee_email)
+            site_licensee_system_user = su_qs.filter(email__iexact=i.site_licensee_email)
             if site_licensee_system_user.exists():
                 site_licensee = get_user_name(site_licensee_system_user.first())["full_name"]
             endorsement = "Not Actioned"

--- a/mooringlicensing/components/proposals/utils.py
+++ b/mooringlicensing/components/proposals/utils.py
@@ -874,7 +874,7 @@ def update_proposal_applicant(proposal, request):
         proposal_applicant.email = proposal_applicant_data['email']
         try:
             if proposal_applicant.email:
-                email_user = EmailUserRO.objects.get(email=proposal_applicant.email)
+                email_user = EmailUserRO.objects.get(email__iexact=proposal_applicant.email)
                 proposal_applicant.email_user_id = email_user.id
         except:
             proposal_applicant.email_user_id = None

--- a/mooringlicensing/utils/mooring_licence_migrate_pd.py
+++ b/mooringlicensing/utils/mooring_licence_migrate_pd.py
@@ -921,7 +921,7 @@ class MooringLicenceReader():
                     self.no_email.append(user_row.pers_no)
                     continue
 
-                users = EmailUser.objects.filter(email=email)
+                users = EmailUser.objects.filter(email__iexact=email)
                 if users.count() == 0:
                     print(f'wl - email not found: {email}')
  
@@ -1069,7 +1069,7 @@ class MooringLicenceReader():
                     self.no_email.append(user_row.pers_no)
                     continue
 
-                users = EmailUser.objects.filter(email=email)
+                users = EmailUser.objects.filter(email__iexact=email)
                 if users.count() == 0:
                     print(f'ml - email not found: {email}')
  
@@ -1647,7 +1647,7 @@ class MooringLicenceReader():
                 first_name = row.first_name.lower().title().strip()
                 last_name = row.last_name.lower().title().strip()
                 try:
-                    user = EmailUser.objects.get(email=email.lower())
+                    user = EmailUser.objects.get(email__iexact=email.lower())
                     user.first_name = first_name
                     user.last_name = last_name
                     user.save()
@@ -1810,7 +1810,7 @@ class MooringLicenceReader():
                 vessel_length = row['vessel_length']
 
                 try:
-                    user = EmailUser.objects.get(email=email.lower().strip())
+                    user = EmailUser.objects.get(email__iexact=email.lower().strip())
                 except Exception as e:
                     errors.append("User with email " + str(email.lower()) + " does not exist") 
                     continue


### PR DESCRIPTION
Some old ledger email addresses are stored with capitalisation.

To accommodate this, all queries using email addresses as a filter or get value now use iexact, which is case insensitive.

Also fixed an incorrectly applied permission on Dcv Admissions viewset.