### PR TITLE
Misc fixes

### DIFF
--- a/mooringlicensing/components/approvals/api.py
+++ b/mooringlicensing/components/approvals/api.py
@@ -276,28 +276,7 @@ class ApprovalFilterBackend(DatatablesFilterBackend):
                 filter_query &= ~Q(waitinglistallocation=None)
 
         queryset = queryset.filter(filter_query)
-        fields = self.get_fields(request)
-        ordering = self.get_ordering(request, view, fields)
-
-        #special handling for ordering by holder
-        special_ordering = False
-        HOLDER = 'holder'
-        REVERSE_HOLDER = '-holder'
-        if HOLDER in ordering:
-            special_ordering = True
-            ordering.remove(HOLDER)
-            queryset = queryset.annotate(holder=Concat('current_proposal__proposal_applicant__first_name',Value(" "),'current_proposal__proposal_applicant__last_name'))
-            queryset = queryset.order_by(HOLDER)
-        if REVERSE_HOLDER in ordering:
-            special_ordering = True
-            ordering.remove(REVERSE_HOLDER)
-            queryset = queryset.annotate(holder=Concat('current_proposal__proposal_applicant__first_name',Value(" "),'current_proposal__proposal_applicant__last_name'))
-            queryset = queryset.order_by(REVERSE_HOLDER)
-
-        if len(ordering):
-            queryset = queryset.order_by(*ordering)
-        elif not special_ordering:
-            queryset = queryset.order_by('-id')
+        
 
         try:
             super_queryset = super(ApprovalFilterBackend, self).filter_queryset(request, queryset, view)
@@ -327,6 +306,29 @@ class ApprovalFilterBackend(DatatablesFilterBackend):
                 queryset = super_queryset.union(q_set)
         except Exception as e:
             logger.error(e)
+
+        fields = self.get_fields(request)
+        ordering = self.get_ordering(request, view, fields)
+
+        #special handling for ordering by holder
+        special_ordering = False
+        HOLDER = 'holder'
+        REVERSE_HOLDER = '-holder'
+        if HOLDER in ordering:
+            special_ordering = True
+            ordering.remove(HOLDER)
+            queryset = queryset.annotate(holder=Concat('current_proposal__proposal_applicant__first_name',Value(" "),'current_proposal__proposal_applicant__last_name'))
+            queryset = queryset.order_by(HOLDER)
+        if REVERSE_HOLDER in ordering:
+            special_ordering = True
+            ordering.remove(REVERSE_HOLDER)
+            queryset = queryset.annotate(holder=Concat('current_proposal__proposal_applicant__first_name',Value(" "),'current_proposal__proposal_applicant__last_name'))
+            queryset = queryset.order_by(REVERSE_HOLDER)
+
+        if len(ordering):
+            queryset = queryset.order_by(*ordering)
+        elif not special_ordering:
+            queryset = queryset.order_by('-id')
 
         total_count = queryset.count()
         setattr(view, '_datatables_filtered_count', total_count)
@@ -1649,12 +1651,6 @@ class StickerFilterBackend(DatatablesFilterBackend):
         if filter_sticker_status_id and not filter_sticker_status_id.lower() == 'all':
             queryset = queryset.filter(status=filter_sticker_status_id)
 
-        fields = self.get_fields(request)
-        ordering = self.get_ordering(request, view, fields)
-        queryset = queryset.order_by(*ordering)
-        if len(ordering):
-            queryset = queryset.order_by(*ordering)
-
         #re-arranged filter so that: 
         #1) if the records in ledger and local are different they do not cancel each other out
         #2) other filters DO override the custom search
@@ -1673,6 +1669,13 @@ class StickerFilterBackend(DatatablesFilterBackend):
                 queryset = super_queryset.union(q_set)
         except Exception as e:
             print(e)
+
+        fields = self.get_fields(request)
+        ordering = self.get_ordering(request, view, fields)
+        queryset = queryset.order_by(*ordering)
+        if len(ordering):
+            queryset = queryset.order_by(*ordering)
+            
         setattr(view, '_datatables_total_count', total_count)
         
         return queryset

--- a/mooringlicensing/components/approvals/api.py
+++ b/mooringlicensing/components/approvals/api.py
@@ -279,10 +279,13 @@ class ApprovalFilterBackend(DatatablesFilterBackend):
         queryset = queryset.filter(filter_query)
         fields = self.get_fields(request)
         ordering = self.get_ordering(request, view, fields)
-        queryset = queryset.order_by(*ordering)
+
+        #TODO special handling for ordering by holder
+        special_ordering = False
+        
         if len(ordering):
             queryset = queryset.order_by(*ordering)
-        else:
+        elif not special_ordering:
             queryset = queryset.order_by('-id')
 
         try:
@@ -1631,7 +1634,10 @@ class StickerFilterBackend(DatatablesFilterBackend):
 
         fields = self.get_fields(request)
         ordering = self.get_ordering(request, view, fields)
-        queryset = queryset.order_by(*ordering)
+
+        #TODO special handling for ordering by holder
+        special_ordering = False
+        print(ordering)
         if len(ordering):
             queryset = queryset.order_by(*ordering)
 

--- a/mooringlicensing/components/approvals/api.py
+++ b/mooringlicensing/components/approvals/api.py
@@ -280,9 +280,21 @@ class ApprovalFilterBackend(DatatablesFilterBackend):
         fields = self.get_fields(request)
         ordering = self.get_ordering(request, view, fields)
 
-        #TODO special handling for ordering by holder
+        #special handling for ordering by holder
         special_ordering = False
-        
+        HOLDER = 'holder'
+        REVERSE_HOLDER = '-holder'
+        if HOLDER in ordering:
+            special_ordering = True
+            ordering.remove(HOLDER)
+            queryset = queryset.annotate(holder=Concat('current_proposal__proposal_applicant__first_name',Value(" "),'current_proposal__proposal_applicant__last_name'))
+            queryset = queryset.order_by(HOLDER)
+        if REVERSE_HOLDER in ordering:
+            special_ordering = True
+            ordering.remove(REVERSE_HOLDER)
+            queryset = queryset.annotate(holder=Concat('current_proposal__proposal_applicant__first_name',Value(" "),'current_proposal__proposal_applicant__last_name'))
+            queryset = queryset.order_by(REVERSE_HOLDER)
+
         if len(ordering):
             queryset = queryset.order_by(*ordering)
         elif not special_ordering:
@@ -1634,10 +1646,7 @@ class StickerFilterBackend(DatatablesFilterBackend):
 
         fields = self.get_fields(request)
         ordering = self.get_ordering(request, view, fields)
-
-        #TODO special handling for ordering by holder
-        special_ordering = False
-        print(ordering)
+        queryset = queryset.order_by(*ordering)
         if len(ordering):
             queryset = queryset.order_by(*ordering)
 

--- a/mooringlicensing/components/approvals/models.py
+++ b/mooringlicensing/components/approvals/models.py
@@ -290,7 +290,7 @@ class Approval(RevisionedMixin):
     )
     APPROVED_STATUSES = [
         APPROVAL_STATUS_CURRENT,
-        APPROVAL_STATUS_SURRENDERED,
+        APPROVAL_STATUS_SUSPENDED,
     ]
     lodgement_number = models.CharField(max_length=9, blank=True, unique=True)
     status = models.CharField(max_length=40, choices=STATUS_CHOICES, default=STATUS_CHOICES[0][0])

--- a/mooringlicensing/components/approvals/serializers.py
+++ b/mooringlicensing/components/approvals/serializers.py
@@ -726,7 +726,7 @@ class ListApprovalSerializer(serializers.ModelSerializer):
                             'bay_name': moa.mooring.mooring_bay.name,
                             'mooring_name': moa.mooring.name,
                         })
-            elif type(obj.child_obj) == MooringLicence and obj.child_obj.mooring and obj.child_obj.mooring.mooring_bay: 
+            elif type(obj.child_obj) == MooringLicence and hasattr(obj.child_obj,'mooring') and obj.child_obj.mooring.mooring_bay: 
                 links.append({
                     'id': obj.child_obj.mooring.id,
                     'bay_name': obj.child_obj.mooring.mooring_bay.name,

--- a/mooringlicensing/components/compliances/api.py
+++ b/mooringlicensing/components/compliances/api.py
@@ -274,6 +274,7 @@ class GetComplianceStatusesDict(views.APIView):
 
 class ComplianceFilterBackend(DatatablesFilterBackend):
     def filter_queryset(self, request, queryset, view):
+
         filter_compliance_status = request.GET.get('filter_compliance_status')
         if filter_compliance_status and not filter_compliance_status.lower() == 'all':
             queryset = queryset.filter(processing_status=filter_compliance_status)
@@ -293,11 +294,11 @@ class ComplianceFilterBackend(DatatablesFilterBackend):
                     Q(first_name__icontains=search_text) | Q(last_name__icontains=search_text) | Q(email__icontains=search_text) | Q(full_name__icontains=search_text)
                 ).values_list("proposal_id", flat=True))
                 q_set = queryset.filter(Q(approval__current_proposal__id__in=proposal_applicant_proposals)|Q(approval__current_proposal__submitter__in=system_user_ids))
+                q_set.annotate(lodgement_number="lodgement_number")
                 queryset = super_queryset.union(q_set)
 
             total_count = queryset.count()
             setattr(view, '_datatables_filtered_count', total_count)
-            return queryset
         except Exception as e:
             logger.error(f'ComplianceFilterBackend raises an error: [{e}].  Query may not work correctly.')
 
@@ -318,7 +319,7 @@ class ComplianceFilterBackend(DatatablesFilterBackend):
 
         if len(ordering):
             queryset = queryset.order_by(*ordering)
-
+        
         total_count = queryset.count()
         setattr(view, '_datatables_filtered_count', total_count)
         return queryset

--- a/mooringlicensing/components/compliances/api.py
+++ b/mooringlicensing/components/compliances/api.py
@@ -277,25 +277,7 @@ class ComplianceFilterBackend(DatatablesFilterBackend):
         filter_compliance_status = request.GET.get('filter_compliance_status')
         if filter_compliance_status and not filter_compliance_status.lower() == 'all':
             queryset = queryset.filter(processing_status=filter_compliance_status)
-
-        fields = self.get_fields(request)
-        ordering = self.get_ordering(request, view, fields)
-
-        #special handling for ordering by holder
-        HOLDER = 'approval_holder'
-        REVERSE_HOLDER = '-approval_holder'
-        if HOLDER in ordering:
-            ordering.remove(HOLDER)
-            queryset = queryset.annotate(approval_holder=Concat('approval__current_proposal__proposal_applicant__first_name',Value(" "),'approval__current_proposal__proposal_applicant__last_name'))
-            queryset = queryset.order_by(HOLDER)
-        if REVERSE_HOLDER in ordering:
-            ordering.remove(REVERSE_HOLDER)
-            queryset = queryset.annotate(approval_holder=Concat('approval__current_proposal__proposal_applicant__first_name',Value(" "),'approval__current_proposal__proposal_applicant__last_name'))
-            queryset = queryset.order_by(REVERSE_HOLDER)
-
-        if len(ordering):
-            queryset = queryset.order_by(*ordering)
-
+        
         try:
             super_queryset = super(ComplianceFilterBackend, self).filter_queryset(request, queryset, view)
 
@@ -318,6 +300,25 @@ class ComplianceFilterBackend(DatatablesFilterBackend):
             return queryset
         except Exception as e:
             logger.error(f'ComplianceFilterBackend raises an error: [{e}].  Query may not work correctly.')
+
+        fields = self.get_fields(request)
+        ordering = self.get_ordering(request, view, fields)
+
+        #special handling for ordering by holder
+        HOLDER = 'approval_holder'
+        REVERSE_HOLDER = '-approval_holder'
+        if HOLDER in ordering:
+            ordering.remove(HOLDER)
+            queryset = queryset.annotate(approval_holder=Concat('approval__current_proposal__proposal_applicant__first_name',Value(" "),'approval__current_proposal__proposal_applicant__last_name'))
+            queryset = queryset.order_by(HOLDER)
+        if REVERSE_HOLDER in ordering:
+            ordering.remove(REVERSE_HOLDER)
+            queryset = queryset.annotate(approval_holder=Concat('approval__current_proposal__proposal_applicant__first_name',Value(" "),'approval__current_proposal__proposal_applicant__last_name'))
+            queryset = queryset.order_by(REVERSE_HOLDER)
+
+        if len(ordering):
+            queryset = queryset.order_by(*ordering)
+
         total_count = queryset.count()
         setattr(view, '_datatables_filtered_count', total_count)
         return queryset

--- a/mooringlicensing/components/compliances/api.py
+++ b/mooringlicensing/components/compliances/api.py
@@ -280,7 +280,19 @@ class ComplianceFilterBackend(DatatablesFilterBackend):
 
         fields = self.get_fields(request)
         ordering = self.get_ordering(request, view, fields)
-        queryset = queryset.order_by(*ordering)
+
+        #special handling for ordering by holder
+        HOLDER = 'approval_holder'
+        REVERSE_HOLDER = '-approval_holder'
+        if HOLDER in ordering:
+            ordering.remove(HOLDER)
+            queryset = queryset.annotate(approval_holder=Concat('approval__current_proposal__proposal_applicant__first_name',Value(" "),'approval__current_proposal__proposal_applicant__last_name'))
+            queryset = queryset.order_by(HOLDER)
+        if REVERSE_HOLDER in ordering:
+            ordering.remove(REVERSE_HOLDER)
+            queryset = queryset.annotate(approval_holder=Concat('approval__current_proposal__proposal_applicant__first_name',Value(" "),'approval__current_proposal__proposal_applicant__last_name'))
+            queryset = queryset.order_by(REVERSE_HOLDER)
+
         if len(ordering):
             queryset = queryset.order_by(*ordering)
 

--- a/mooringlicensing/components/proposals/api.py
+++ b/mooringlicensing/components/proposals/api.py
@@ -598,8 +598,20 @@ class ProposalFilterBackend(DatatablesFilterBackend):
         fields = self.get_fields(request)
         ordering = self.get_ordering(request, view, fields)
         
-        #TODO special handling for ordering by applicant, assigned_to
+        #special handling for ordering by applicant
         special_ordering = False
+        APPLICANT = 'applicant'
+        REVERSE_APPLICANT = '-applicant'
+        if APPLICANT in ordering:
+            special_ordering = True
+            ordering.remove(APPLICANT)
+            queryset = queryset.annotate(applicant_full_name=Concat('proposal_applicant__first_name',Value(" "),'proposal_applicant__last_name'))
+            queryset = queryset.order_by(APPLICANT+"_full_name")
+        if REVERSE_APPLICANT in ordering:
+            special_ordering = True
+            ordering.remove(REVERSE_APPLICANT)
+            queryset = queryset.annotate(applicant_full_name=Concat('proposal_applicant__first_name',Value(" "),'proposal_applicant__last_name'))
+            queryset = queryset.order_by(REVERSE_APPLICANT+"_full_name")
 
         if len(ordering):
             queryset = queryset.order_by(*ordering)

--- a/mooringlicensing/components/proposals/api.py
+++ b/mooringlicensing/components/proposals/api.py
@@ -597,10 +597,13 @@ class ProposalFilterBackend(DatatablesFilterBackend):
 
         fields = self.get_fields(request)
         ordering = self.get_ordering(request, view, fields)
-        queryset = queryset.order_by(*ordering)
+        
+        #TODO special handling for ordering by applicant, assigned_to
+        special_ordering = False
+
         if len(ordering):
             queryset = queryset.order_by(*ordering)
-        else:
+        elif not special_ordering:
             queryset = queryset.order_by('-id')
         
         total_count = queryset.count()

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -4405,7 +4405,8 @@ class Vessel(RevisionedMixin):
         approval_filter &= ~Q(status__in=[
                     Approval.APPROVAL_STATUS_CANCELLED,
                     Approval.APPROVAL_STATUS_EXPIRED,
-                    Approval.APPROVAL_STATUS_SURRENDERED])
+                    Approval.APPROVAL_STATUS_SURRENDERED,
+                    Approval.APPROVAL_STATUS_FULFILLED])
         
         blocking_approvals = []
         blocking_aup = []

--- a/mooringlicensing/components/proposals/serializers.py
+++ b/mooringlicensing/components/proposals/serializers.py
@@ -1601,8 +1601,6 @@ class SaveVesselOwnershipSerializer(serializers.ModelSerializer):
                 'owner',
                 'vessel',
                 'percentage',
-                'start_date',
-                'end_date',
                 'dot_name',
                 'company_ownerships',
                 )

--- a/mooringlicensing/components/proposals/utils.py
+++ b/mooringlicensing/components/proposals/utils.py
@@ -567,9 +567,6 @@ def store_vessel_ownership(request, vessel, instance):
                 vessel_ownership.company_ownerships.add(company_ownership)
                 logger.info(f'CompanyOwnership: [{company_ownership}] has been added to the company_ownerships field of the VesselOwnership: [{vessel_ownership}].')
             vo_created = True
-            if vo_created:
-                vessel_ownership_data["start_date"] = datetime.datetime.now()
-                vessel_ownership_data["end_date"] = None
 
         q_for_approvals_check &= ~Q(id=instance.approval.id)  # We want to exclude the approval we are currently processing for
     else:
@@ -610,11 +607,11 @@ def store_vessel_ownership(request, vessel, instance):
         vessel.check_blocking_ownership(vessel_ownership, instance)
 
     # save temp doc if exists
-    handle_vessel_registrarion_documents_in_limbo(instance.id, vessel_ownership)
+    handle_vessel_registration_documents_in_limbo(instance.id, vessel_ownership)
 
     return vessel_ownership
 
-def handle_vessel_registrarion_documents_in_limbo(proposal_id, vessel_ownership):
+def handle_vessel_registration_documents_in_limbo(proposal_id, vessel_ownership):
     # VesselRegistrationDocument object with proposal is the documents stored for the draft proposal
     documents_in_limbo = VesselRegistrationDocument.objects.filter(proposal_id=proposal_id)
 

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/table_approvals.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/table_approvals.vue
@@ -695,7 +695,7 @@ export default {
             return {
                 data: "id",
                 orderable: false,
-                searchable: true,
+                searchable: false,
                 visible: true,
                 'render': function(row, type, full){
                     let ret = ''

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/table_approvals.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/table_approvals.vue
@@ -268,8 +268,8 @@ export default {
                     'Id',
                     'Number',
                     'Type',
-                    'Sticker number/s',
-                    'Sticker mailed date',
+                    'Sticker Number/s',
+                    'Sticker Mailed Date',
                     'Status',
                     'Issue Date',
                     'Start Date',
@@ -277,9 +277,8 @@ export default {
                     'Vessel Rego',
                     'Mooring',
                     'Action',
-                    'Grace period end date',
-                    'Approval letter',
-                    //'Sticker replacement',
+                    'Grace Period End Date',
+                    'Approval Letter',
                 ]
             } else if (this.is_internal && this.wlaDash) {
                 return [
@@ -644,27 +643,6 @@ export default {
                         name: 'stickers__number',
                     }
         },
-        /*columnStickerReplacement: function(){
-            return {
-                        data: "id",
-                        orderable: false,
-                        searchable: false,
-                        visible: true,
-                        'render': function(row, type, full){
-                            let ret_str = ''
-                            for (let sticker of full.stickers_historical){
-                                if (sticker.invoices.length){
-                                    for (let invoice of sticker.invoices){
-                                        // ret_str += invoice.invoice_url
-                                        ret_str += "<div><a href='" + invoice.invoice_url +"' target='_blank'><i style='color:red;' class='fa fa-file-pdf-o'></i> #" + invoice.reference + "</a></div>"
-                                    }
-                                }
-                            }
-                            return ret_str
-                        },
-
-            }
-        },*/
         columnStickerMailedDate: function() {
             return {
                         data: "id",
@@ -727,7 +705,7 @@ export default {
         columnVesselRegos: function() {
             return {
                 data: "id",
-                orderable: true,
+                orderable: false,
                 searchable: true,
                 visible: true,
                 'render': function(row, type, full){

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/table_approvals.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/table_approvals.vue
@@ -10,26 +10,15 @@
         </div>
         <div v-else class="row">
             <div v-if="!wlaDash">
-                    <div class="col-md-3">
-                        <div class="form-group">
-                            <label for="">Type:</label>
-                            <select class="form-control" v-model="filterApprovalType">
-                                <option value="All">All</option>
-                                <option v-for="type in approvalTypes" :value="type.code">{{ type.description }}</option>
-                            </select>
-                        </div>
+                <div class="col-md-3">
+                    <div class="form-group">
+                        <label for="">Type:</label>
+                        <select class="form-control" v-model="filterApprovalType">
+                            <option value="All">All</option>
+                            <option v-for="type in approvalTypes" :value="type.code">{{ type.description }}</option>
+                        </select>
                     </div>
-                <!--div v-if="is_internal">
-                    <div class="col-md-3">
-                        <div class="form-group">
-                            <label for="">Holder:</label>
-                            <select class="form-control" v-model="filterHolder">
-                                <option value="All">All</option>
-                                <option v-for="h in holderList" :value="h.id">{{ h.full_name }}</option>
-                            </select>
-                        </div>
-                    </div>
-                </div-->
+                </div>
             </div>
             <div v-else>
                 <div class="col-md-3">

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/table_approvals.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/table_approvals.vue
@@ -541,13 +541,13 @@ export default {
         columnHolder: function() {
             return {
                         data: "id",
-                        orderable: false,
+                        orderable: true,
                         searchable: false,
                         visible: true,
                         'render': function(row, type, full){
                             return full.holder;
                         },
-                        name: 'current_proposal__proposalapplicant__first_name, current_proposal__proposalapplicant__last_name, current_proposal__proposalapplicant__email'
+                        name: 'holder'
                     }
         },
         columnPreferredMooringBay: function() {

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/table_compliances.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/table_compliances.vue
@@ -81,13 +81,13 @@ export default {
         approvalHolderColumn: function() {
             return {
                         data: "id",
-                        orderable: false,
+                        orderable: true,
                         searchable: false,
                         visible: true,
                         'render': function(row, type, full){
                             return full.approval_holder;
                         },
-                        // name: 'proposal__proposalapplicant__first_name'
+                        name: 'approval_holder'
                     }
         },
         approvalTypeColumn: function() {

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/table_proposals.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/table_proposals.vue
@@ -19,15 +19,6 @@
                     </select>
                 </div>
             </div>
-            <!--<div class="col-md-3" v-if="is_internal">
-                <div class="form-group">
-                    <label for="">Applicant</label>
-                    <select class="form-control" v-model="filterApplicant">
-                        <option value="All">All</option>
-                        <option v-for="applicant in applicants" :value="applicant.id">{{ applicant.first_name }} {{ applicant.last_name }}</option>
-                    </select>
-                </div>
-            </div>-->
             <div class="col-md-3">
                 <div class="form-group">
                     <label for="">Status</label>

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/table_proposals.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/table_proposals.vue
@@ -185,7 +185,7 @@ export default {
             return {
                 // 4. Application Type (This corresponds to the 'ProposalType' at the backend)
                 data: "id",
-                orderable: true,
+                orderable: false,
                 searchable: true,
                 visible: true,
                 'render': function(row, type, full){

--- a/mooringlicensing/frontend/mooringlicensing/src/components/common/table_proposals.vue
+++ b/mooringlicensing/frontend/mooringlicensing/src/components/common/table_proposals.vue
@@ -308,7 +308,7 @@ export default {
         column_applicant: function(){
             return {
                 data: "id",
-                orderable: false,
+                orderable: true,
                 searchable: false, //special functionality for searching this field required
                 visible: true,
                 'render': function(row, type, full){
@@ -321,7 +321,7 @@ export default {
                     }
                     return ''
                 },
-                name: 'proposal_applicant__first_name, proposal_applicant__last_name, proposal_applicant__email'
+                name: 'applicant'
             }
         },
         column_assigned_to: function(){

--- a/mooringlicensing/management/commands/approval_renewal_notices.py
+++ b/mooringlicensing/management/commands/approval_renewal_notices.py
@@ -80,9 +80,9 @@ class Command(BaseCommand):
                 a.log_user_action(ApprovalUserAction.ACTION_RENEWAL_NOTICE_SENT_FOR_APPROVAL.format(a),)
                 logger.info(ApprovalUserAction.ACTION_RENEWAL_NOTICE_SENT_FOR_APPROVAL.format(a))
                 updates.append(a.lodgement_number)
-            except Exception as e:
+            except:# Exception as e:
                 err_msg = 'Error sending renewal notice for Approval {}'.format(a.lodgement_number)
-                logger.error('{}\n{}'.format(err_msg, str(e)))
+                logger.error(err_msg)
                 errors.append(err_msg)
 
     def handle(self, *args, **options):


### PR DESCRIPTION
Number of fixes for found and reported issues:

- various dashboard table numbers fixed to display accurate values
- fixed error caused by a mooring license not having a mooring (e.g. mid-swap)
- added ordering to applicant/holder columns
- added searching for approval vessel rego numbers
- removed ordering from approval vessel rego numbers
- fixed problem where Annual Admission Permits vessels would inherit the sale date of the previous ownership record
- fixed an issue with renewal management script that would break renewal process if at least one record fails
- fixed a number of additional ordering/searching issues
