### PR TITLE
Vessel save change

### DIFF
--- a/mooringlicensing/components/payments_ml/models.py
+++ b/mooringlicensing/components/payments_ml/models.py
@@ -154,7 +154,10 @@ class StickerActionFee(Payment):
 class FeeItemApplicationFee(models.Model):
     fee_item = models.ForeignKey('FeeItem', on_delete=models.CASCADE)
     application_fee = models.ForeignKey('ApplicationFee', on_delete=models.CASCADE)
-    vessel_details = models.ForeignKey(VesselDetails, null=True, blank=True, on_delete=models.SET_NULL)
+    
+    #TODO change FeeApplicationFee model - do not refer to model, store required values in this model directly
+    vessel_details = models.ForeignKey(VesselDetails, null=True, blank=True, on_delete=models.SET_NULL) 
+
     amount_to_be_paid = models.DecimalField(max_digits=8, decimal_places=2, null=True, blank=True, default=None)
     amount_paid = models.DecimalField(max_digits=8, decimal_places=2, null=True, blank=True, default=None)
 

--- a/mooringlicensing/components/payments_ml/models.py
+++ b/mooringlicensing/components/payments_ml/models.py
@@ -154,10 +154,7 @@ class StickerActionFee(Payment):
 class FeeItemApplicationFee(models.Model):
     fee_item = models.ForeignKey('FeeItem', on_delete=models.CASCADE)
     application_fee = models.ForeignKey('ApplicationFee', on_delete=models.CASCADE)
-    
-    #TODO change FeeApplicationFee model - do not refer to model, store required values in this model directly
     vessel_details = models.ForeignKey(VesselDetails, null=True, blank=True, on_delete=models.SET_NULL) 
-
     amount_to_be_paid = models.DecimalField(max_digits=8, decimal_places=2, null=True, blank=True, default=None)
     amount_paid = models.DecimalField(max_digits=8, decimal_places=2, null=True, blank=True, default=None)
 

--- a/mooringlicensing/components/payments_ml/views.py
+++ b/mooringlicensing/components/payments_ml/views.py
@@ -759,7 +759,7 @@ class ApplicationFeeSuccessViewPreload(APIView):
                         fee_item_application_fee = FeeItemApplicationFee.objects.create(
                             fee_item=fee_item,
                             application_fee=application_fee,
-                            vessel_details=proposal.vessel_details,
+                            vessel_details=proposal.vessel_details, #TODO change
                             amount_to_be_paid=amount_to_be_paid,
                             amount_paid=amount_paid,
                         )
@@ -771,6 +771,8 @@ class ApplicationFeeSuccessViewPreload(APIView):
                         fee_amount_adjusted = item['fee_amount_adjusted']
                         amount_to_be_paid = Decimal(fee_amount_adjusted)
                         amount_paid = amount_to_be_paid
+
+                        #TODO change FeeApplicationFee model
                         vessel_details_id = item['vessel_details_id']  # This could be '' when null vessel application
                         vessel_details = VesselDetails.objects.get(id=vessel_details_id) if vessel_details_id else None
                         fee_item_application_fee = FeeItemApplicationFee.objects.create(

--- a/mooringlicensing/components/payments_ml/views.py
+++ b/mooringlicensing/components/payments_ml/views.py
@@ -759,7 +759,6 @@ class ApplicationFeeSuccessViewPreload(APIView):
                         fee_item_application_fee = FeeItemApplicationFee.objects.create(
                             fee_item=fee_item,
                             application_fee=application_fee,
-                            vessel_details=proposal.vessel_details, #TODO change
                             amount_to_be_paid=amount_to_be_paid,
                             amount_paid=amount_paid,
                         )
@@ -772,13 +771,9 @@ class ApplicationFeeSuccessViewPreload(APIView):
                         amount_to_be_paid = Decimal(fee_amount_adjusted)
                         amount_paid = amount_to_be_paid
 
-                        #TODO change FeeApplicationFee model
-                        vessel_details_id = item['vessel_details_id']  # This could be '' when null vessel application
-                        vessel_details = VesselDetails.objects.get(id=vessel_details_id) if vessel_details_id else None
                         fee_item_application_fee = FeeItemApplicationFee.objects.create(
                             fee_item=fee_item,
                             application_fee=application_fee,
-                            vessel_details=vessel_details,
                             amount_to_be_paid=amount_to_be_paid,
                             amount_paid=amount_paid,
                         )
@@ -868,6 +863,12 @@ class ApplicationFeeSuccessView(TemplateView):
                 if type(proposal.child_obj) in [WaitingListApplication, AnnualAdmissionApplication]:
                     if proposal.auto_approve:
                         proposal.final_approval_for_WLA_AAA(request, details={})
+
+                proposal.refresh_from_db()
+
+                #update FeeItemApplicationFee with vessel details
+                fee_item_application_fees = FeeItemApplicationFee.objects.filter(application_fee=application_fee)
+                fee_item_application_fees.update(vessel_details=proposal.vessel_details)
 
                 wla_or_aaa = True if proposal.application_type.code in [WaitingListApplication.code, AnnualAdmissionApplication.code,] else False
                 invoice = Invoice.objects.get(reference=application_fee.invoice_reference)

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -2614,7 +2614,7 @@ class WaitingListApplication(Proposal):
 
         # Get blocking approvals
         approvals = Approval.objects.filter(
-            Q(current_proposal__vessel_ownership__vessel=vessel) &
+            (Q(current_proposal__vessel_ownership__vessel=vessel) | Q(current_proposal__vessel_ownership__vessel__rego_no=self.rego_no))
             (Q(current_proposal__vessel_ownership__end_date__gt=today) | 
             Q(current_proposal__vessel_ownership__end_date=None))
         ).exclude(id=self.approval_id).filter(status__in=Approval.APPROVED_STATUSES)
@@ -2863,7 +2863,7 @@ class AnnualAdmissionApplication(Proposal):
 
         # Get blocking approvals
         approvals = Approval.objects.filter(
-            Q(current_proposal__vessel_ownership__vessel=vessel) &
+            (Q(current_proposal__vessel_ownership__vessel=vessel) | Q(current_proposal__vessel_ownership__vessel__rego_no=self.rego_no)) &
             (Q(current_proposal__vessel_ownership__end_date__gt=today) | 
             Q(current_proposal__vessel_ownership__end_date=None))
         ).exclude(id=self.approval_id).filter(status__in=Approval.APPROVED_STATUSES)
@@ -3084,7 +3084,7 @@ class AuthorisedUserApplication(Proposal):
 
         # Get blocking approvals
         approvals = Approval.objects.filter(
-            Q(current_proposal__vessel_ownership__vessel=vessel) &
+            (Q(current_proposal__vessel_ownership__vessel=vessel) | Q(current_proposal__vessel_ownership__vessel__rego_no=self.rego_no)) &
             (Q(current_proposal__vessel_ownership__end_date__gt=today) | 
             Q(current_proposal__vessel_ownership__end_date=None))
         ).exclude(id=self.approval_id).filter(status__in=Approval.APPROVED_STATUSES)
@@ -3589,7 +3589,7 @@ class MooringLicenceApplication(Proposal):
 
         # Get blocking approvals
         approvals = Approval.objects.filter(
-            Q(current_proposal__vessel_ownership__vessel=vessel) &
+            (Q(current_proposal__vessel_ownership__vessel=vessel) | Q(current_proposal__vessel_ownership__vessel__rego_no=self.rego_no)) &
             (Q(current_proposal__vessel_ownership__end_date__gt=today) | 
             Q(current_proposal__vessel_ownership__end_date=None))
         ).exclude(id=self.approval_id).filter(status__in=Approval.APPROVED_STATUSES)

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -2640,11 +2640,11 @@ class WaitingListApplication(Proposal):
                 blocking_approvals.append(approval) 
 
         if (blocking_proposals):
-            msg = f'The vessel: {self.vessel_ownership.vessel} is already listed in another active waiting list or mooring license application'
+            msg = f'The vessel: {self.rego_no} is already listed in another active application'
             logger.error(msg)
             raise serializers.ValidationError(msg)
         elif (blocking_approvals):
-            msg = f'The vessel: {self.vessel_ownership.vessel} is already listed in another active waiting list or mooring license'
+            msg = f'The vessel: {self.rego_no} is already listed in another active license'
             logger.error(msg)
             raise serializers.ValidationError(msg)
         # Person can have only one WLA, Waiting List application, Mooring Licence, and Mooring Licence application

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -2686,8 +2686,8 @@ class WaitingListApplication(Proposal):
 
         application_type = self.application_type
 
-        if self.vessel_details:
-            vessel_length = self.vessel_details.vessel_applicable_length
+        if self.vessel_length:
+            vessel_length = self.vessel_length
         else:
             # No vessel specified in the application
             if self.does_accept_null_vessel:

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -2618,9 +2618,14 @@ class WaitingListApplication(Proposal):
 
         # Get blocking approvals
         approvals = Approval.objects.filter(
-            (Q(current_proposal__vessel_ownership__vessel=vessel) | Q(current_proposal__vessel_ownership__vessel__rego_no=self.rego_no))
-            (Q(current_proposal__vessel_ownership__end_date__gt=today) | 
-            Q(current_proposal__vessel_ownership__end_date=None))
+            (
+                Q(current_proposal__vessel_ownership__vessel=vessel) | 
+                Q(current_proposal__vessel_ownership__vessel__rego_no=self.rego_no)
+            ) &
+            (
+                Q(current_proposal__vessel_ownership__end_date__gt=today) | 
+                Q(current_proposal__vessel_ownership__end_date=None)
+            )
         ).exclude(id=self.approval_id).filter(status__in=Approval.APPROVED_STATUSES)
 
         blocking_approvals = []
@@ -2879,9 +2884,14 @@ class AnnualAdmissionApplication(Proposal):
 
         # Get blocking approvals
         approvals = Approval.objects.filter(
-            (Q(current_proposal__vessel_ownership__vessel=vessel) | Q(current_proposal__vessel_ownership__vessel__rego_no=self.rego_no)) &
-            (Q(current_proposal__vessel_ownership__end_date__gt=today) | 
-            Q(current_proposal__vessel_ownership__end_date=None))
+            (
+                Q(current_proposal__vessel_ownership__vessel=vessel) | 
+                Q(current_proposal__vessel_ownership__vessel__rego_no=self.rego_no)
+            ) &
+            (
+                Q(current_proposal__vessel_ownership__end_date__gt=today) | 
+                Q(current_proposal__vessel_ownership__end_date=None)
+            )
         ).exclude(id=self.approval_id).filter(status__in=Approval.APPROVED_STATUSES)
 
         approvals_ml = []
@@ -3113,9 +3123,14 @@ class AuthorisedUserApplication(Proposal):
 
         # Get blocking approvals
         approvals = Approval.objects.filter(
-            (Q(current_proposal__vessel_ownership__vessel=vessel) | Q(current_proposal__vessel_ownership__vessel__rego_no=self.rego_no)) &
-            (Q(current_proposal__vessel_ownership__end_date__gt=today) | 
-            Q(current_proposal__vessel_ownership__end_date=None))
+            (
+                Q(current_proposal__vessel_ownership__vessel=vessel) | 
+                Q(current_proposal__vessel_ownership__vessel__rego_no=self.rego_no)
+            ) &
+            (
+                Q(current_proposal__vessel_ownership__end_date__gt=today) | 
+                Q(current_proposal__vessel_ownership__end_date=None)
+            )
         ).exclude(id=self.approval_id).filter(status__in=Approval.APPROVED_STATUSES)
         approvals_aup = []
         approvals_other = []
@@ -3634,9 +3649,14 @@ class MooringLicenceApplication(Proposal):
 
         # Get blocking approvals
         approvals = Approval.objects.filter(
-            (Q(current_proposal__vessel_ownership__vessel=vessel) | Q(current_proposal__vessel_ownership__vessel__rego_no=self.rego_no)) &
-            (Q(current_proposal__vessel_ownership__end_date__gt=today) | 
-            Q(current_proposal__vessel_ownership__end_date=None))
+            (
+                Q(current_proposal__vessel_ownership__vessel=vessel) | 
+                Q(current_proposal__vessel_ownership__vessel__rego_no=self.rego_no)
+            ) &
+            (
+                Q(current_proposal__vessel_ownership__end_date__gt=today) | 
+                Q(current_proposal__vessel_ownership__end_date=None)
+            )
         ).exclude(id=self.approval_id).filter(status__in=Approval.APPROVED_STATUSES)
 
         approvals_ml = []

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -1548,9 +1548,12 @@ class Proposal(DirtyFieldsMixin, RevisionedMixin):
                 raise
 
     def final_approval_for_WLA_AAA(self, request, details=None):
+        from mooringlicensing.components.proposals.utils import submit_vessel_data
         with transaction.atomic():
             try:
                 logger.info(f'Processing final_approval...for the proposal: [{self}].')
+
+                submit_vessel_data(self, request, approving=True)
 
                 current_datetime = datetime.datetime.now(pytz.timezone(TIME_ZONE))
                 self.proposed_decline_status = False
@@ -1706,7 +1709,10 @@ class Proposal(DirtyFieldsMixin, RevisionedMixin):
         with transaction.atomic():
             try:
                 from mooringlicensing.components.approvals.models import Sticker
+                from mooringlicensing.components.proposals.utils import submit_vessel_data
                 logger.info(f'Processing final_approval... for the proposal: [{self}].')
+
+                submit_vessel_data(self, request, approving=True)
 
                 self.proposed_decline_status = False
 

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -2591,7 +2591,7 @@ class WaitingListApplication(Proposal):
         # Get blocking proposals 
         # Checking if there are any applications still in progress
         proposals = Proposal.objects.filter(
-            (Q(vessel_details__vessel=vessel) &
+            ((Q(vessel_details__vessel=vessel) & ~Q(vessel_details__vessel=None)) &
             (Q(vessel_ownership__end_date__gt=today) | Q(vessel_ownership__end_date__isnull=True)) |
             Q(rego_no=self.rego_no)) & # Vessel has not been sold yet
             ~Q(processing_status__in=[  # Blocking proposal's status is not in the statuses listed
@@ -2613,7 +2613,7 @@ class WaitingListApplication(Proposal):
                     blocking_proposals.append(proposal)
                 elif (proposal.proposal_applicant and 
                     self.proposal_applicant and 
-                    proposal.proposal_applicant.email_user_id != self.proposal_applicant.email_user_id):
+                    proposal.proposal_applicant.email_user_id != self.proposal_applicant.email_user_id):            
                     blocking_proposals.append(proposal)
 
         # Get blocking approvals
@@ -2850,7 +2850,7 @@ class AnnualAdmissionApplication(Proposal):
 
         # Get blocking proposals
         proposals = Proposal.objects.filter(
-            (Q(vessel_details__vessel=vessel) &
+            ((Q(vessel_details__vessel=vessel) & ~Q(vessel_details__vessel=None)) &
             (Q(vessel_ownership__end_date__gt=today) | Q(vessel_ownership__end_date__isnull=True)) |
             Q(rego_no=self.rego_no)) & # Vessel has not been sold yet
             ~Q(processing_status__in=[  # Blocking proposal's status is not in the statuses listed
@@ -3096,7 +3096,7 @@ class AuthorisedUserApplication(Proposal):
 
         # Get blocking proposals
         proposals = Proposal.objects.filter(
-            (Q(vessel_details__vessel=vessel) &
+            ((Q(vessel_details__vessel=vessel) & ~Q(vessel_details__vessel=None)) &
             (Q(vessel_ownership__end_date__gt=today) | Q(vessel_ownership__end_date__isnull=True)) |
             Q(rego_no=self.rego_no)) & # Vessel has not been sold yet
             ~Q(processing_status__in=[  # Blocking proposal's status is not in the statuses listed
@@ -3622,7 +3622,7 @@ class MooringLicenceApplication(Proposal):
 
         # Get blocking proposals
         proposals = Proposal.objects.filter(
-            (Q(vessel_details__vessel=vessel) &
+            ((Q(vessel_details__vessel=vessel) & ~Q(vessel_details__vessel=None)) &
             (Q(vessel_ownership__end_date__gt=today) | Q(vessel_ownership__end_date__isnull=True)) |
             Q(rego_no=self.rego_no)) & # Vessel has not been sold yet
             ~Q(processing_status__in=[  # Blocking proposal's status is not in the statuses listed

--- a/mooringlicensing/components/proposals/serializers.py
+++ b/mooringlicensing/components/proposals/serializers.py
@@ -725,7 +725,7 @@ class SaveAnnualAdmissionApplicationSerializer(serializers.ModelSerializer):
                 pass 
             else:
                 insurance_choice = data.get("insurance_choice")
-                vessel_length = proposal.vessel_details.vessel_applicable_length
+                vessel_length = proposal.vessel_length
                 if not insurance_choice:
                     custom_errors["Insurance Choice"] = "You must make an insurance selection"
                 elif vessel_length > Decimal("6.4") and insurance_choice not in ['ten_million', 'over_ten']:
@@ -759,12 +759,12 @@ class SaveMooringLicenceApplicationSerializer(serializers.ModelSerializer):
 
         if self.context.get("action") == 'submit':
             if not ignore_insurance_check:
-                renewal_or_amendment_application_with_vessel = proposal.proposal_type.code in [PROPOSAL_TYPE_RENEWAL, PROPOSAL_TYPE_AMENDMENT,] and proposal.vessel_details
+                renewal_or_amendment_application_with_vessel = proposal.proposal_type.code in [PROPOSAL_TYPE_RENEWAL, PROPOSAL_TYPE_AMENDMENT,] and proposal.vessel_details #TODO review if this would work
                 new_application = proposal.proposal_type.code == PROPOSAL_TYPE_NEW
                 if renewal_or_amendment_application_with_vessel or new_application:
                     logger.info(f'This proposal: [{self.instance}] is a new proposal or a renewal/amendment proposal with a vessel.')
                     insurance_choice = data.get("insurance_choice")
-                    vessel_length = proposal.vessel_details.vessel_applicable_length
+                    vessel_length = proposal.vessel_length
                     if not insurance_choice:
                         custom_errors["Insurance Choice"] = "You must make an insurance selection"
                     elif vessel_length > Decimal("6.4") and insurance_choice not in ['ten_million', 'over_ten']:
@@ -817,7 +817,7 @@ class SaveAuthorisedUserApplicationSerializer(serializers.ModelSerializer):
         if self.context.get("action") == 'submit':
             if not ignore_insurance_check:
                 insurance_choice = data.get("insurance_choice")
-                vessel_length = proposal.vessel_details.vessel_applicable_length
+                vessel_length = proposal.vessel_length
                 if not insurance_choice:
                     custom_errors["Insurance Choice"] = "You must make an insurance selection"
                 elif vessel_length > Decimal("6.4") and insurance_choice not in ['ten_million', 'over_ten']:

--- a/mooringlicensing/components/proposals/utils.py
+++ b/mooringlicensing/components/proposals/utils.py
@@ -954,7 +954,7 @@ def get_max_vessel_length_for_main_component(proposal):
 
     fee_item_application_fees = FeeItemApplicationFee.objects.filter(application_fee__proposal_id__in=proposal_id_list).filter(fee_item__fee_constructor__application_type=proposal_application_type)
     for fee_item_application_fee in fee_item_application_fees:     
-        length_tuple = fee_item_application_fee.get_max_allowed_length()
+        length_tuple = fee_item_application_fee.get_max_allowed_length() #TODO change
         if max_vessel_length[0] < length_tuple[0] or (max_vessel_length[0] == length_tuple[0] and length_tuple[1] == True):
             max_vessel_length = length_tuple
 

--- a/mooringlicensing/components/proposals/utils.py
+++ b/mooringlicensing/components/proposals/utils.py
@@ -451,7 +451,7 @@ def store_vessel_ownership(request, vessel, instance):
 
     ## Get Vessel
     ## we cannot use vessel_data, because this dict has been modified in store_vessel_data()
-    if request.data.get('vessel'):
+    if hasattr(request,'data') and request.data.get('vessel'):
         vessel_ownership_data = deepcopy(request.data.get('vessel').get("vessel_ownership"))
     else:
         vessel_data = {

--- a/mooringlicensing/components/proposals/utils.py
+++ b/mooringlicensing/components/proposals/utils.py
@@ -471,6 +471,13 @@ def store_vessel_ownership(request, vessel, instance):
                 "dot_name": instance.dot_name,
             },
         }
+        if instance.individual_owner:
+            vessel_data["vessel_ownership"]["percentage"] = instance.percentage
+        else:    
+            vessel_data["vessel_ownership"]["company_ownership"] = {
+                "company": {"name": instance.company_ownership_name},
+                "percentage": instance.company_ownership_percentage,
+            }
         vessel_ownership_data = vessel_data["vessel_ownership"]
 
     if vessel_ownership_data.get('individual_owner') is None:
@@ -678,7 +685,6 @@ def handle_document(instance, vessel_ownership, request_data, *args, **kwargs):
 def ownership_percentage_validation(proposal):
     logger.info(f'Calculating the total vessel ownership percentage of the draft vessel: [{proposal.rego_no}]...')
 
-    individual_ownership_id = None
     company_ownership_id = None
     min_percent_fail = False
     vessel_ownership_percentage = 0
@@ -725,7 +731,7 @@ def ownership_percentage_validation(proposal):
                     ):
                         total_percent += company_ownership.percentage
                         logger.info(f'Vessel ownership to be taken into account in the calculation: {company_ownership}')
-            elif vo.percentage and vo.id != individual_ownership_id:
+            elif vo.percentage:
                 total_percent += vo.percentage
                 logger.info(f'Vessel ownership to be taken into account in the calculation: {vo}')
 

--- a/mooringlicensing/components/proposals/utils.py
+++ b/mooringlicensing/components/proposals/utils.py
@@ -110,15 +110,7 @@ def save_proponent_data_aaa(instance, request, action):
     update_proposal_applicant(instance.child_obj, request)
     instance.refresh_from_db()
     instance.child_obj.set_auto_approve(request)
-    instance.refresh_from_db()
-    #TODO rework/remove
-    #if action == 'submit':
-    #    if instance.invoice and get_invoice_payment_status(instance.id) in ['paid', 'over_paid'] and not instance.auto_approve:
-    #        # Save + Submit + Paid ==> We have to update the status
-    #        # Probably this is the case that assessor put back this application to external and then external submit this.
-    #        logger.info('Proposal {} has been submitted but already paid.  Update the status of it to {}'.format(instance.lodgement_number, Proposal.PROCESSING_STATUS_WITH_ASSESSOR))
-    #        instance.processing_status = Proposal.PROCESSING_STATUS_WITH_ASSESSOR
-    #        instance.save()     
+    instance.refresh_from_db()   
 
 
 def save_proponent_data_wla(instance, request, action):
@@ -150,14 +142,7 @@ def save_proponent_data_wla(instance, request, action):
     update_proposal_applicant(instance.child_obj, request)
     instance.refresh_from_db()
     instance.child_obj.set_auto_approve(request)
-    #TODO rework/remove
-    #if action == 'submit':
-    #    if instance.invoice and get_invoice_payment_status(instance.invoice.id) in ['paid', 'over_paid']:
-    #        # Save + Submit + Paid ==> We have to update the status
-    #        # Probably this is the case that assessor put back this application to external and then external submit this.
-    #        logger.info('Proposal {} has been submitted but already paid.  Update the status of it to {}'.format(instance.lodgement_number, Proposal.PROCESSING_STATUS_WITH_ASSESSOR))
-    #        instance.processing_status = Proposal.PROCESSING_STATUS_WITH_ASSESSOR
-    #        instance.save()
+
 
 def save_proponent_data_mla(instance, request, action):
     logger.info(f'Saving proponent data of the proposal: [{instance}]')
@@ -376,21 +361,23 @@ def submit_vessel_data(instance, request, vessel_data):
     # Update Proposal obj
     save_vessel_data(instance, request, vessel_data)
 
-    # Update VesselDetails obj
-    vessel, vessel_details = store_vessel_data(request, vessel_data)
+    #TODO on approval only
+    if None:
+        # Update VesselDetails obj
+        vessel, vessel_details = store_vessel_data(request, vessel_data)
 
-    # Associate the vessel_details with the proposal
-    instance.vessel_details = vessel_details
-    instance.save()
+        # Associate the vessel_details with the proposal
+        instance.vessel_details = vessel_details
+        instance.save()
 
-    # record ownership data
-    vessel_ownership = store_vessel_ownership(request, vessel, instance)
-    instance.vessel_ownership = vessel_ownership
-    instance.save()
+        # record ownership data
+        vessel_ownership = store_vessel_ownership(request, vessel, instance)
+        instance.vessel_ownership = vessel_ownership
+        instance.save()
 
-    instance.validate_against_existing_proposals_and_approvals()
+        instance.validate_against_existing_proposals_and_approvals() #TODO change
 
-    ownership_percentage_validation(vessel_ownership, instance)
+        ownership_percentage_validation(vessel_ownership, instance) #TODO change
 
 
 def store_vessel_data(request, vessel_data):
@@ -610,7 +597,7 @@ def store_vessel_ownership(request, vessel, instance):
 
     # check and set blocking_owner
     if instance:
-        vessel.check_blocking_ownership(vessel_ownership, instance)
+        vessel.check_blocking_ownership(vessel_ownership, instance) #TODO this needs to be changed or duplicated so it works without a vessel record
 
     # save temp doc if exists
     handle_vessel_registration_documents_in_limbo(instance.id, vessel_ownership)

--- a/mooringlicensing/utils/mooring_licence_migrate_pd.py
+++ b/mooringlicensing/utils/mooring_licence_migrate_pd.py
@@ -2295,7 +2295,7 @@ def create_application_fee(proposal):
                 fee_item_application_fee = FeeItemApplicationFee.objects.create(
                     fee_item=fee_item,
                     application_fee=application_fee,
-                    vessel_details=proposal.vessel_details, #TODO change to use new model fields
+                    vessel_details=proposal.vessel_details,
                     amount_to_be_paid=amount_to_be_paid,
                     amount_paid=amount_paid,
                 )
@@ -2311,7 +2311,7 @@ def create_application_fee(proposal):
                 fee_item_application_fee = FeeItemApplicationFee.objects.create(
                     fee_item=fee_item,
                     application_fee=application_fee,
-                    vessel_details=vessel_details, #TODO change to use new model fields
+                    vessel_details=vessel_details,
                     amount_to_be_paid=amount_to_be_paid,
                     amount_paid=amount_paid,
                 )

--- a/mooringlicensing/utils/mooring_licence_migrate_pd.py
+++ b/mooringlicensing/utils/mooring_licence_migrate_pd.py
@@ -2295,7 +2295,7 @@ def create_application_fee(proposal):
                 fee_item_application_fee = FeeItemApplicationFee.objects.create(
                     fee_item=fee_item,
                     application_fee=application_fee,
-                    vessel_details=proposal.vessel_details,
+                    vessel_details=proposal.vessel_details, #TODO change to use new model fields
                     amount_to_be_paid=amount_to_be_paid,
                     amount_paid=amount_paid,
                 )
@@ -2311,7 +2311,7 @@ def create_application_fee(proposal):
                 fee_item_application_fee = FeeItemApplicationFee.objects.create(
                     fee_item=fee_item,
                     application_fee=application_fee,
-                    vessel_details=vessel_details,
+                    vessel_details=vessel_details, #TODO change to use new model fields
                     amount_to_be_paid=amount_to_be_paid,
                     amount_paid=amount_paid,
                 )


### PR DESCRIPTION
Changes when the Vessel and VesselOwnership instances are created during the application workflow.

They now are created on the application's approval, instead of submission. This means that declined or otherwise cancelled applications will no longer permanently alter any existing Vessel record. 

A number of changes have been made to accommodate the workflow adjustments, including:
- proposal vessel ownership validation checks at the submission and approval stages
- vessel ownership percentage checks
- proposal fee calculation
- vessel details acquisition

