### PR TITLE
max number of renewal notices per application

### DIFF
--- a/mooringlicensing/settings.py
+++ b/mooringlicensing/settings.py
@@ -18,6 +18,7 @@ DISABLE_EMAIL = env('DISABLE_EMAIL', False)
 SHOW_TESTS_URL = env('SHOW_TESTS_URL', False)
 SHOW_DEBUG_TOOLBAR = env('SHOW_DEBUG_TOOLBAR', False)
 SHOW_API_ROOT = env('SHOW_API_ROOT', False)
+MAX_RENEWAL_NOTICES_PER_RUN = env('MAX_RENEWAL_NOTICES_PER_RUN', 5)
 
 #Settings for rounding application fee items
 ROUND_FEE_ITEMS = env('ROUND_FEE_ITEMS', False)

--- a/python-cron
+++ b/python-cron
@@ -2,5 +2,6 @@
 10 * * * * python manage_ml.py import_mooring_bookings_data >> logs/run_import_mooring_bookings_data_cron_task.log 2>&1
 */10 * * * * python manage_ml.py export_to_mooring_booking_cron_task >> logs/run_export_to_mooring_booking_cron_task.log 2>&1
 */5 * * * * python manage_ml.py runcrons >> logs/runcrons.log 2>&1
+*/4 * * * * python manage_ml.py approval_renewal_notices >> logs/run_approval_renewal_notices_cron_task.log 2>&1
 30 3 * * 4 python manage_ml.py clearsessions >> logs/clearsessions.log 2>&1
 30 * * * * python manage_ml.py auto_lock_system_account >> logs/auto_lock_system_account.log 2>&1


### PR DESCRIPTION
Approval Renewal Notices management command will now only send a maximum of 5 (configurable) renewal notices per relevant approval type (4).

The cron job for it is now set to run every 4 minutes.