### PR TITLE
Submission fix

### DIFF
--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -2331,6 +2331,8 @@ class Proposal(DirtyFieldsMixin, RevisionedMixin):
         return False
     
     def vessel_mooring_compatible(self, mooring):
+        if not self.vessel_length or not self.vessel_draft or not self.vessel_weight:
+            return False
         if (self.vessel_length > mooring.vessel_size_limit or
             self.vessel_draft > mooring.vessel_draft_limit or
             (mooring.vessel_weight_limit and self.vessel_weight > mooring.vessel_weight_limit)):

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -2719,7 +2719,7 @@ class WaitingListApplication(Proposal):
         # Get blocking approvals
         approvals = Approval.objects.filter(
             (
-                Q(current_proposal__vessel_ownership__vessel=vessel) | 
+                (Q(current_proposal__vessel_ownership__vessel=vessel) & ~Q(current_proposal__vessel_ownership__vessel=None)) | 
                 Q(current_proposal__vessel_ownership__vessel__rego_no=self.rego_no)
             ) &
             (

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -1601,6 +1601,9 @@ class Proposal(DirtyFieldsMixin, RevisionedMixin):
                     if not i.mooring:
                         raise serializers.ValidationError("Mooring does not exist")
                     
+                    if not self.vessel_length or not self.vessel_draft or not self.vessel_weight:
+                        raise serializers.ValidationError("One or more vessel dimensions are not specified")
+
                     if (self.vessel_length > i.mooring.vessel_size_limit or
                         self.vessel_draft > i.mooring.vessel_draft_limit or
                         (self.vessel_weight > i.mooring.vessel_weight_limit and i.mooring.vessel_weight_limit > 0)):


### PR DESCRIPTION
There was a problem with new WLA and AUA proposals not being accepted on the basis of vessel registration number already been in use when they actually were not.

Investigation revealed that the blocking approvals check included approvals with proposals where the vessel ownership fields were set to None. Because new proposals also have vessel ownership fields set to None, effectively any approved proposal with no vessel ownership would render all application unable to be submitted.

This would not usually be a problem as all approved proposals should have vessel ownership set, however an exception to this has occurred on UAT. This PR fixes the validation query to only retrieve approved proposals with vessel ownerships set (using the rego_no otherwise) to allow submissions even after the unexpected behaviour has occurred.

Further work to determine how an accepted proposal exists without a vessel ownership can happen and what, if any, further impact it may have.

Some general validation fixes RE vessel dimensions have also been included.