### PR TITLE
Missing ownership

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,5 +11,5 @@
 		   "--hostname","mooringlicensing-dev"
 		   ],
 	"forwardPorts": [9121,9122,9123,9124,9125],
-	"initializeCommand" : "${localEnv:HOME}/docker-scripts-dev/windows_vbox/postgres_docker_load_2404.sh && ${localEnv:HOME}/docker-scripts-dev/windows_vbox/ledger_docker_load.sh "
+	"initializeCommand" : "${localEnv:HOME}/docker-scripts-dev/windows_vbox/postgres_docker_load_2404_16.sh && ${localEnv:HOME}/docker-scripts-dev/windows_vbox/ledger_docker_load.sh "
 }

--- a/mooringlicensing/components/payments_ml/models.py
+++ b/mooringlicensing/components/payments_ml/models.py
@@ -476,8 +476,9 @@ class FeeConstructor(models.Model):
         try:
             fee_constructor = None
             fee_constructor_qs = cls.objects.filter(application_type=application_type,)\
-                .filter(fee_season__fee_periods__start_date__lte=target_date, enabled=True).order_by('fee_season__fee_periods__start_date')
-            
+                .annotate(s_date=Min("fee_season__fee_periods__start_date"))\
+                .filter(s_date__lte=target_date, enabled=True).order_by('s_date')
+
             # Validation
             if not fee_constructor_qs:
                 raise Exception('No fees are configured for the application type: {} on the date: {}'.format(application_type, target_date))

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -3507,6 +3507,7 @@ class AuthorisedUserApplication(Proposal):
                     send_notification_email_upon_submit_to_assessor(request, self)
 
     def update_or_create_approval(self, current_datetime, request=None):
+        from mooringlicensing.components.proposals.utils import submit_vessel_data
         logger.info(f'Updating/Creating Authorised User Permit from the application: [{self}]...')
         # This function is called after payment success for new/amendment/renewal application
         # Manage approval
@@ -3531,6 +3532,10 @@ class AuthorisedUserApplication(Proposal):
                 self.save()
 
         elif self.proposal_type.code == PROPOSAL_TYPE_AMENDMENT:
+            if self.auto_approve and request:
+                submit_vessel_data(self, request, approving=True)
+                self.refresh_from_db()
+
             # When amendment application
             approval = self.approval.child_obj
             approval.current_proposal = self
@@ -3540,6 +3545,10 @@ class AuthorisedUserApplication(Proposal):
             approval.submitter = self.submitter
             approval.save()
         elif self.proposal_type.code == PROPOSAL_TYPE_RENEWAL:
+            if self.auto_approve and request:
+                submit_vessel_data(self, request, approving=True)
+                self.refresh_from_db()
+
             # When renewal application
             approval = self.approval.child_obj
             approval.current_proposal = self
@@ -4064,6 +4073,7 @@ class MooringLicenceApplication(Proposal):
         logger.info(f'Status: [{self.processing_status}] has been set to the proposal: [{self}].')
 
     def update_or_create_approval(self, current_datetime, request=None):
+        from mooringlicensing.components.proposals.utils import submit_vessel_data
         logger.info(f'Updating/Creating Mooring Site Licence from the application: [{self}]...')
         try:
             # renewal/amendment/reissue - associated ML must have a mooring
@@ -4085,6 +4095,11 @@ class MooringLicenceApplication(Proposal):
                 approval.current_proposal=self
                 approval.issue_date = current_datetime
                 approval.start_date = current_datetime.date()
+
+                if self.auto_approve and request:
+                    submit_vessel_data(self, request, approving=True)
+                    self.refresh_from_db()
+
                 if self.proposal_type.code == PROPOSAL_TYPE_RENEWAL:
                     # When renewal, we have to update the expiry_date of the approval
                     approval.expiry_date = self.end_date

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -2296,6 +2296,7 @@ class Proposal(DirtyFieldsMixin, RevisionedMixin):
             vessel_exists = (True if
                 self.approval and self.approval.current_proposal and 
                 self.approval.current_proposal.vessel_details and
+                self.approval.current_proposal.vessel_ownership and
                 not self.approval.current_proposal.vessel_ownership.end_date #end_date means sold
                 else False)
         else:

--- a/mooringlicensing/components/proposals/utils.py
+++ b/mooringlicensing/components/proposals/utils.py
@@ -271,7 +271,7 @@ def save_vessel_data(instance, request, vessel_data):
     vessel_details_data = {}
     vessel_id = vessel_data.get('id')
     vessel_details_data = vessel_data.get("vessel_details")
-
+    
     # update vessel details to vessel_data
     for key in vessel_details_data.keys():
         vessel_data.update({key: vessel_details_data.get(key)})
@@ -292,7 +292,11 @@ def save_vessel_data(instance, request, vessel_data):
         vessel_data.update({key: vessel_ownership_data.get(key)})
 
     # overwrite vessel_data.id with correct value
-    if not (type(instance.child_obj) == MooringLicenceApplication and vessel_data.get('readonly')): 
+    obj = instance
+    if type(instance) == Proposal:
+        obj = instance.child_obj
+
+    if not (type(obj) == MooringLicenceApplication and vessel_data.get('readonly')): 
         serializer = SaveDraftProposalVesselSerializer(instance, vessel_data)
         serializer.is_valid(raise_exception=True)
         serializer.save()

--- a/mooringlicensing/components/proposals/utils.py
+++ b/mooringlicensing/components/proposals/utils.py
@@ -399,7 +399,7 @@ def submit_vessel_data(instance, request, vessel_data=None, approving=False):
 
         # record ownership data
         vessel_ownership = store_vessel_ownership(request, vessel, instance)
-        instance.vessel_ownership = vessel_ownership
+        instance.vessel_ownership = vessel_ownership #TODO investigate why this would ever be None
         instance.save()
 
     instance.validate_against_existing_proposals_and_approvals()


### PR DESCRIPTION
Fixes missing ownership for certain applications.

After investigation it was found that auto-approved amendments to AUAs (and MLAs) were missing the required logic to generate vessel ownership records, as that logic was only present during the approval process. Because AUPs and MLAs are usually paid for post-approval, they did not logic to generate vessels after payment. 

Now auto approval is checked post-payment for these application types so that they generated vessel ownership data the same as if approved normally.