### PR TITLE
Auto Approve Vessel Cat Change

### DIFF
--- a/mooringlicensing/components/proposals/api.py
+++ b/mooringlicensing/components/proposals/api.py
@@ -2123,10 +2123,7 @@ class VesselOwnershipViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin)
             sale_date = request.data.get('sale_date')
 
             logger.info(f'Recording vessel sale of the vessel_ownership: [{instance}] with the sale_date: {sale_date}')
-            print("\n\n\n\n\n",instance)
             if sale_date:
-                print(sale_date)
-                print(instance.end_date)
                 if not instance.end_date:
                     # proposals with instance copied to listed_vessels
                     for proposal in instance.listed_on_proposals.all():
@@ -2140,8 +2137,6 @@ class VesselOwnershipViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin)
                                     "You cannot record the sale of this vessel at this time as application {} that lists this vessel is still in progress.".format(proposal.lodgement_number)
                                     )
 
-                print("\n\n\n???\n\n")
-
                 ## setting the end_date "removes" the vessel from current Approval records
                 serializer = SaveVesselOwnershipSaleDateSerializer(instance, {"end_date": sale_date})
                 serializer.is_valid(raise_exception=True)
@@ -2149,7 +2144,6 @@ class VesselOwnershipViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin)
                 logger.info(f'Vessel sold: VesselOwnership: [{instance}] has been updated with the end_date: [{sale_date}].')
 
                 instance.refresh_from_db()
-                print("???\n\n\n\n",instance.end_date)
 
                 ## collect impacted Approvals
                 approval_list = []

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -2354,7 +2354,6 @@ class Proposal(DirtyFieldsMixin, RevisionedMixin):
             current_datetime_str = current_datetime.astimezone(pytz.timezone(TIME_ZONE)).strftime('%d/%m/%Y %I:%M %p')
             target_date = self.get_target_date(current_datetime.date())
             #category of application
-            print(self.does_accept_null_vessel)
             new_category = get_vessel_length_category(target_date, self.vessel_length, self.proposal_type, self.application_type)
             #category of existing vessel (using params of application aside from the actual vessel_length)
             #we use the category of the current application because different applications types have their own ranges - we want to check the classification of the length of each vessel on the same terms

--- a/mooringlicensing/components/proposals/utils.py
+++ b/mooringlicensing/components/proposals/utils.py
@@ -957,6 +957,13 @@ def get_file_content_http_response(file_path):
         response['Content-Disposition'] = 'inline;filename={}'.format(f_name)
         return response
     
+def get_vessel_length_category(target_date, vessel_length, proposal_type, application_type):
+    from mooringlicensing.components.payments_ml.models import FeeConstructor
+    
+    fee_constructor = FeeConstructor.get_fee_constructor_by_application_type_and_date(application_type, target_date)
+    fee_item = fee_constructor.get_fee_item(vessel_length, proposal_type, target_date)
+
+    return fee_item.id
 
 def get_max_vessel_length_for_main_component(proposal):
     #get the max vessel allowed before payment change is required


### PR DESCRIPTION
Denies auto approval to MLA, WLA, and AUA where the vessel length category of the provided vessel length is different to the vessel length on record. 

Prior to this auto approval would only be denied if the applicant would have to pay more, typically only if an amendment submitted a vessel length higher than all previous submissions for a given license. Now auto approval is blocked regardless of increased payment, and even when the submitted length is in a length lower category.

Note that the submitted vessel length is compared to most recent prior submission of the vessel with the same rego no (not necessarily the last submission for the given license).