### PR TITLE
Sanitise Additions

### DIFF
--- a/mooringlicensing/components/main/utils.py
+++ b/mooringlicensing/components/main/utils.py
@@ -652,35 +652,29 @@ def remove_script_tags(text):
     if text is None:
         return None
 
-    SCRIPT_TAGS_WRAPPED = re.compile(r'(?i)<script+>.+</script+>')
-    SCRIPT_TAGS_NO_WRAPPED = re.compile(r'(?i)<script+>')
+    SCRIPT_TAGS_WRAPPED = re.compile(r'(?i)<script[^>]+>.+</script[^>]+>')
+    SCRIPT_TAGS_NO_WRAPPED = re.compile(r'(?i)<script[^>]+>')
 
     text = SCRIPT_TAGS_WRAPPED.sub('', text)
     text = SCRIPT_TAGS_NO_WRAPPED.sub('', text)
-    return text
 
-def remove_html_tags(text):
+    ATTR_BLACKLIST = ['onresize','onvolumechange','onsuspend','onpopstate','onbeforeunload','oncontextmenu',
+        'ondragstart','oncuechange','onselect','onafterprint','onmouseover','ondragleave','onstorage',
+        'onbeforeprint','onhashchange','onabort','ondragover','onwaiting','onclick','onmousemove','onkeyup',
+        'onmousedown','ononline','onsearch','onprogress','onfocus','onmouseup','onplaying','onstalled','oninvalid',
+        'ontimeupdate','onkeypress','onseeked','onreset','onwheel','onemptied','oninput','onpagehide','onpause',
+        'onloadeddata','onseeking','onunload','onpageshow','onerror','ondrop','oncanplay','oncopy','onended','oncut',
+        'onsubmit','ondrag','onblur','ondragend','onplay','onratechange','onloadedmetadata','oncanplaythrough',
+        'ondurationchange','onchange','ondblclick','onmousewheel','onpaste','onload','onscroll','onkeydown',
+        'ontoggle','onmouseout','onoffline','onloadstart','ondragenter']
+    ATTR_BLACKLIST_STR=('|').join(ATTR_BLACKLIST)
 
-    if text is None:
-        return None
+    HTML_TAGS_WITH_ATTR_WRAPPED = re.compile(r'(?i)<[^>]+('+ATTR_BLACKLIST_STR+')[\s]*=[^>]+>.+</[^>]+>')
+    HTML_TAGS_WITH_ATTR_NO_WRAPPED = re.compile(r'(?i)<[^>]+('+ATTR_BLACKLIST_STR+')[\s]*=[^>]+>')
 
-    HTML_TAGS_WRAPPED = re.compile(r'<[^>]+>.+</[^>]+>')
-    HTML_TAGS_NO_WRAPPED = re.compile(r'<[^>]+>')
+    text = HTML_TAGS_WITH_ATTR_WRAPPED.sub('', text)
+    text = HTML_TAGS_WITH_ATTR_NO_WRAPPED.sub('', text)
 
-    text = HTML_TAGS_WRAPPED.sub('', text)
-    text = HTML_TAGS_NO_WRAPPED.sub('', text)
-    return text
-
-def remove_script_tags(text):
-
-    if text is None:
-        return None
-
-    SCRIPT_TAGS_WRAPPED = re.compile(r'(?i)<script+>.+</script+>')
-    SCRIPT_TAGS_NO_WRAPPED = re.compile(r'(?i)<script+>')
-
-    text = SCRIPT_TAGS_WRAPPED.sub('', text)
-    text = SCRIPT_TAGS_NO_WRAPPED.sub('', text)
     return text
 
 def is_json(value):
@@ -695,14 +689,17 @@ def sanitise_fields(instance, exclude=[], error_on_change=[]):
         for i in instance.__dict__:
             #remove html tags for all string fields not in the exclude list
             if not i in exclude and (isinstance(instance.__dict__[i], dict)):
-                sanitise_fields(instance.__dict__[i])
+                instance.__dict__[i] = sanitise_fields(instance.__dict__[i])
             
-            elif isinstance(instance.__dict__[i], list):
+            elif isinstance(instance.__dict__[i], list) and not i in exclude:
                 for j in range(0, len(instance.__dict__[i])):
+                    check = instance.__dict__[i][j]
                     if isinstance(instance.__dict__[i][j],str):
                         instance.__dict__[i][j] = remove_html_tags(instance.__dict__[i][j])
                     elif isinstance(instance.__dict__[i][j], list) or isinstance(instance.__dict__[i][j], dict):
-                        sanitise_fields(instance.__dict__[i][j])
+                        instance.__dict__[i][j] = sanitise_fields(instance.__dict__[i][j])
+                    if i in error_on_change and check != instance.__dict__[i][j]:
+                        raise serializers.ValidationError("html tags included in field")
             
             elif isinstance(instance.__dict__[i], str) and not i in exclude:
                 check = instance.__dict__[i]
@@ -716,6 +713,31 @@ def sanitise_fields(instance, exclude=[], error_on_change=[]):
                 if i in error_on_change and check != instance.__dict__[i]:
                     #only fields that cannot be allowed to change through sanitisation just before saving will throw an error
                     raise serializers.ValidationError("script tags included in field")
+            elif (isinstance(instance.__dict__[i], list) or isinstance(instance.__dict__[i], dict)) and i in exclude:
+                #if we have reached this point, it means we have a json object with fields that are allowed to contain tags
+                #we'll use . notation to identify sub fields that should be carried over to the exclude and error on change lists
+                #NOTE: to allow sub fields to be sanitised, the parent field should be included in both lists required for their respective children
+                sub_exclude_list = list(filter(lambda e:e.startswith(i+"."), exclude))
+                exclude_list = list(map(lambda e:e.replace(i+".","",1), sub_exclude_list))
+                #NOTE: a sub error on change list will require the parent field to be in the exclude list, to reach this point (but not necessarily in the error_on_change list)
+                sub_error_on_change_list = list(filter(lambda e:e.startswith(i+"."), error_on_change))
+                error_on_change_list = list(map(lambda e:e.replace(i+".","",1), sub_error_on_change_list))
+
+                if isinstance(instance.__dict__[i], dict):
+                    check = instance.__dict__[i]
+                    instance.__dict__[i] = sanitise_fields(instance.__dict__[i], exclude=exclude_list, error_on_change=error_on_change_list)
+                    if i in error_on_change and check != instance.__dict__[i]:
+                        raise serializers.ValidationError("html tags included in field")
+                elif isinstance(instance.__dict__[i], list):
+                    for j in range(0, len(instance.__dict__[i])):
+                        check = instance.__dict__[i][j]
+                        if isinstance(instance.__dict__[i][j],str):
+                            #strings in an excluded list will be treated as excluded
+                            instance.__dict__[i][j] = remove_script_tags(instance.__dict__[i][j])
+                        elif isinstance(instance.__dict__[i][j], list) or isinstance(instance.__dict__[i][j], dict):
+                            instance.__dict__[i][j] = sanitise_fields(instance.__dict__[i][j], exclude=exclude_list, error_on_change=error_on_change_list)
+                        if i in error_on_change and check != instance.__dict__[i][j]:
+                            raise serializers.ValidationError("html tags included in field")
     else:
         remove_keys = []
         for i in instance:
@@ -726,16 +748,20 @@ def sanitise_fields(instance, exclude=[], error_on_change=[]):
                 if original_key != sanitised_key:
                     remove_keys.append(original_key)
                     continue
+
             #remove html tags for all string fields not in the exclude list
             if not i in exclude and (isinstance(instance[i], dict)):
-                sanitise_fields(instance[i])
+                instance[i] = sanitise_fields(instance[i])
 
-            elif isinstance(instance[i], list):
+            elif isinstance(instance[i], list) and not i in exclude:
                 for j in range(0, len(instance[i])):
+                    check = instance[i][j]
                     if isinstance(instance[i][j],str):
                         instance[i][j] = remove_html_tags(instance[i][j])
                     elif isinstance(instance[i][j], list) or isinstance(instance[i][j], dict):
-                        sanitise_fields(instance[i][j])
+                        instance[i][j] = sanitise_fields(instance[i][j])
+                    if i in error_on_change and check != instance[i][j]:
+                        raise serializers.ValidationError("html tags included in field")
 
             else:
                 if isinstance(instance[i], str) and not i in exclude:
@@ -750,6 +776,31 @@ def sanitise_fields(instance, exclude=[], error_on_change=[]):
                     if i in error_on_change and check != instance[i]:
                         #only fields that cannot be allowed to change through sanitisation just before saving will throw an error
                         raise serializers.ValidationError("script tags included in field")
+                elif (isinstance(instance[i], list) or isinstance(instance[i], dict)) and i in exclude:
+                    #if we have reached this point, it means we have a json object with fields that are allowed to contain tags
+                    #we'll use . notation to identify sub fields that should be carried over to the exclude and error on change lists
+                    #NOTE: to allow sub fields to be sanitised, the parent field should be included in both lists required for their respective children
+                    sub_exclude_list = list(filter(lambda e:e.startswith(i+"."), exclude))
+                    exclude_list = list(map(lambda e:e.replace(i+".","",1), sub_exclude_list))
+                    #NOTE: a sub error on change list will require the parent field to be in the exclude list, to reach this point (but not necessarily in the error_on_change list)
+                    sub_error_on_change_list = list(filter(lambda e:e.startswith(i+"."), error_on_change))
+                    error_on_change_list = list(map(lambda e:e.replace(i+".","",1), sub_error_on_change_list))
+
+                    if isinstance(instance[i], dict):
+                        check = instance[i]
+                        instance[i] = sanitise_fields(instance[i], exclude=exclude_list, error_on_change=error_on_change_list)
+                        if i in error_on_change and check != instance[i]:
+                            raise serializers.ValidationError("script tags included in field")
+                    elif isinstance(instance[i], list):                        
+                        for j in range(0, len(instance[i])):
+                            check = instance[i][j]
+                            if isinstance(instance[i][j],str):
+                                #strings in an excluded list will be treated as excluded
+                                instance[i][j] = remove_script_tags(instance[i][j])
+                            elif isinstance(instance[i][j], list) or isinstance(instance[i][j], dict):
+                                instance[i][j] = sanitise_fields(instance[i][j], exclude=exclude_list, error_on_change=error_on_change_list)
+                            if i in error_on_change and check != instance[i][j]:
+                                raise serializers.ValidationError("script tags included in field")
                     
         for i in remove_keys:
             del instance[i]


### PR DESCRIPTION
Work on sanitisation functions

Script tag removal function, run for all fields including those exclude from full sanitisation, now also check for blacklisted attributes (anything that can run javascript e.g. onclick)

Excluded fields can also have json sub-fields specified for sanitisation exception (script tags and blacklisted attrs still removed)

Sub-fields that need to excluded can be done so by including the parent in the exclude_sanitise and the child attached to that parent with dot notation. Children included will be excluded from dict or lists of dicts.

For example, an exclusion list with ["test_field", "test_field.test_sub_field"] will now exempt any dict with the key test_sub_field assign to a dict named test_field or a dict in list named test_field.

Note: these changes should not effect mooring licensing functionality, but are updated for consistency and in case required at a later time.