### PR TITLE
Fee calc change

### DIFF
--- a/mooringlicensing/components/payments_ml/models.py
+++ b/mooringlicensing/components/payments_ml/models.py
@@ -662,9 +662,7 @@ class FeeItem(models.Model):
         else:
             # This self.amount is the incremental amount.
             vessel_size = float(vessel_size)
-            number_of_increment = ceil(vessel_size - 0.00)
-
-            absolute_amount = self.amount * number_of_increment
+            absolute_amount = Decimal(round(float(self.amount) * vessel_size,2))
             logger.info(f'Absolute amount calculated: $[{absolute_amount}] from the FeeItem: [{self}] and the vessel_size: [{vessel_size}].')
             return absolute_amount
 

--- a/mooringlicensing/components/payments_ml/models.py
+++ b/mooringlicensing/components/payments_ml/models.py
@@ -662,7 +662,7 @@ class FeeItem(models.Model):
         else:
             # This self.amount is the incremental amount.
             vessel_size = float(vessel_size)
-            absolute_amount = Decimal(round(float(self.amount) * vessel_size,2))
+            absolute_amount = Decimal(round(Decimal(self.amount) * Decimal(vessel_size),2))
             logger.info(f'Absolute amount calculated: $[{absolute_amount}] from the FeeItem: [{self}] and the vessel_size: [{vessel_size}].')
             return absolute_amount
 

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -584,7 +584,7 @@ class Proposal(RevisionedMixin):
             self.proposal_applicant.email_user_id
         ) else None
 
-    #TODO replace max_amount_paid with max_previous_vessel_length
+    
     def get_fee_amount_adjusted(self, fee_item_being_applied, previous_fee_item, vessel_length, previous_vessel_length):
         """
         Retrieve all the fee_items for this vessel

--- a/mooringlicensing/components/proposals/utils.py
+++ b/mooringlicensing/components/proposals/utils.py
@@ -363,9 +363,8 @@ def submit_vessel_data(instance, request, vessel_data=None, approving=False):
     vessel_lookup_errors = {}
     # Mooring Licence vessel history
     # Migrated records do not have DOT name, so only run dot check for new vessel submissions
-    print(instance, instance.id)
-    if isinstance(instance,MooringLicenceApplication) and instance.approval and not instance.approval.migrated:
-        for vo in instance.approval.vessel_ownership_list:
+    if isinstance(instance,MooringLicenceApplication) and instance.approval and instance.vessel_ownership_list and not instance.approval.migrated:
+        for vo in instance.vessel_ownership_list:
             if vo.dot_name:
                 dot_name = vo.dot_name
                 owner_str = dot_name.replace(" ", "%20")

--- a/mooringlicensing/components/proposals/utils.py
+++ b/mooringlicensing/components/proposals/utils.py
@@ -1013,3 +1013,31 @@ def get_max_vessel_length_for_main_component(proposal):
             max_vessel_length = length_tuple
 
     return max_vessel_length
+
+def get_max_vessel_length_for_previous_proposals(proposal):
+    #get longest vessel length among proposals with their previous iterations (except renewals)
+    max_vessel_length = 0
+    
+    if proposal.proposal_type and proposal.proposal_type.code == PROPOSAL_TYPE_AMENDMENT:
+        proposal_id_list = []
+        vessel_lengths = []
+        continue_loop = True
+
+        #populate the proposal id list with all previous applications, up to the latest renewal or new application
+        #include the latest renewal (if any) but stop checking previous applications after that
+        proposal = proposal.previous_application
+        while continue_loop:
+            if proposal.id in proposal_id_list:
+                continue_loop = False
+                break
+            proposal_id_list.append(proposal.id)
+            vessel_lengths.append(proposal.vessel_length)
+            if (proposal.previous_application and 
+                proposal.proposal_type and 
+                (not proposal.proposal_type.code in [PROPOSAL_TYPE_NEW, PROPOSAL_TYPE_RENEWAL,])):
+                proposal = proposal.previous_application
+            else:
+                continue_loop = False
+        max_vessel_length = max(vessel_lengths)
+
+    return max_vessel_length


### PR DESCRIPTION
- Fees are calculated by direct multiplication to vessel length when set to incremental (instead of per metre)
- Fee deductions are based on previous vessel lengths on the approval within the same year/season (instead of previous amount paid)
- fixed a problem with non-migrated mooring license DOT check

Fee deduction may require review