### PR TITLE
Surrender email change

### DIFF
--- a/mooringlicensing/components/proposals/utils.py
+++ b/mooringlicensing/components/proposals/utils.py
@@ -419,7 +419,8 @@ def submit_vessel_data(instance, request, vessel_data=None, approving=False):
         instance.vessel_ownership = vessel_ownership #TODO investigate why this would ever be None
         instance.save()
 
-    instance.validate_against_existing_proposals_and_approvals()
+    if request:
+        instance.validate_against_existing_proposals_and_approvals()
 
     ownership_percentage_validation(instance)
 
@@ -668,7 +669,7 @@ def store_vessel_ownership(request, vessel, instance):
         logger.info(f'CompanyOwnership: [{company_ownership}] has been added to the company_ownerships field of the VesselOwnership: [{vessel_ownership}].')
 
     # check and set blocking_owner
-    if instance:
+    if instance and request:
         vessel.check_blocking_ownership(vessel_ownership, instance)
 
     # save temp doc if exists

--- a/mooringlicensing/templates/mooringlicensing/emails_2/email_30.html
+++ b/mooringlicensing/templates/mooringlicensing/emails_2/email_30.html
@@ -3,7 +3,14 @@
 {% block content_body %}
 {% include "mooringlicensing/emails_2/salutation.html" %}
 
-
+{% if approval.current_proposal.application_type.code == 'mla' %}
+<p>Thank you for notifying us of the surrender of your {{ approval.description }} {{ approval.lodgement_number }} for mooring site {{ approval.child_obj.mooring.name }} , effective as of {{ surrender_date }}.</p>
+<p>As per your licence conditions you must return all associated sticker(s) from your vessel(s) 
+{% for sticker in stickers_to_be_returned %}
+{{ sticker.number }}{% if forloop.last %}{% else %},{% endif %}
+{% endfor %}
+to the Rottnest Island Authority. Failure to return current boating season stickers to RIA will affect applicable refunds. If you have already returned your sticker(s), your refund will be processed shortly.</p>
+{% else %}
 <p>Thank you for notifying us of the surrender of your {{ approval.description }} {{ approval.lodgement_number }} as of {{ surrender_date }}.</p>
 {% if stickers_to_be_returned|length > 0 %}
 <p>If you have not already done so, per your permit(s) conditions, you are required to return all associated vessel sticker(s)
@@ -12,7 +19,7 @@
     {% endfor %}
 to the Rottnest Island Authority. Failure to return stickers to RIA upon request can result in the cancellation of your {{ approval.description }}. Once revoked, it cannot be reinstated.</p>
 {% endif %}
+{% endif %}
 {% if details %}<p>Details: {{ details }}</p>{% endif %}
 {% include "mooringlicensing/emails/signature-rottnest.html" %}
 {% endblock %}
-

--- a/mooringlicensing/templates/mooringlicensing/emails_2/email_30.txt
+++ b/mooringlicensing/templates/mooringlicensing/emails_2/email_30.txt
@@ -2,6 +2,15 @@
 
 {% block content_body %}
 {% include "mooringlicensing/emails_2/salutation.txt" %}
+
+{% if approval.current_proposal.application_type.code == 'mla' %}
+Thank you for notifying us of the surrender of your {{ approval.description }} {{ approval.lodgement_number }} for mooring site {{ approval.child_obj.mooring.name }} , effective as of {{ surrender_date }}.
+As per your licence conditions you must return all associated sticker(s) from your vessel(s) 
+{% for sticker in stickers_to_be_returned %}
+{{ sticker.number }}{% if forloop.last %}{% else %},{% endif %}
+{% endfor %}
+to the Rottnest Island Authority. Failure to return current boating season stickers to RIA will affect applicable refunds. If you have already returned your sticker(s), your refund will be processed shortly.
+{% else %}
 Your {{ approval.description }} {{ approval.lodgement_number }} has been surrendered as per {{ surrender_date }}.
 {% if stickers_to_be_returned|length > 0 %}
 If you have not already done so, per your permit(s) conditions, you are required to return all associated vessel sticker(s)
@@ -9,6 +18,7 @@ If you have not already done so, per your permit(s) conditions, you are required
     {{ sticker.number }}{% if forloop.last %}{% else %},{% endif %}
     {% endfor %}
 to the Rottnest Island Authority. Failure to return stickers to RIA upon request can result in the cancellation of your {{ approval.description }}. Once revoked, it cannot be reinstated.
+{% endif %}
 {% endif %}
 {% if details %}Details: {{ details }}{% endif %}
 {% include "mooringlicensing/emails/signature-rottnest.txt" %}

--- a/mooringlicensing/templates/mooringlicensing/emails_2/email_30_future.html
+++ b/mooringlicensing/templates/mooringlicensing/emails_2/email_30_future.html
@@ -2,6 +2,14 @@
 
 {% block content_body %}
 {% include "mooringlicensing/emails_2/salutation.html" %}
+{% if approval.current_proposal.application_type.code == 'mla' %}
+<p>Your {{ approval.description }} {{ approval.lodgement_number }} for mooring site {{ approval.child_obj.mooring.name }} will be surrendered as per {{ surrender_date }}.</p>
+<p>As per your licence conditions you must return all associated sticker(s) from your vessel(s)
+{% for sticker in stickers_to_be_returned %}
+{{ sticker.number }}{% if forloop.last %}{% else %},{% endif %}
+{% endfor %}
+to the Rottnest Island Authority. Failure to return current boating season stickers to RIA will affect applicable refunds. If you have already returned your sticker(s), your refund will be processed shortly.</p>
+{% else %}
 <p>Your {{ approval.description }} {{ approval.lodgement_number }} will be surrendered as per {{ surrender_date }}.</p>
 {% if stickers_to_be_returned|length > 0 %}
 <p>If you have not already done so, per your permit(s) conditions, you are required to return all associated vessel sticker(s)
@@ -9,6 +17,7 @@
     {{ sticker.number }}{% if forloop.last %}{% else %},{% endif %}
     {% endfor %}
 to the Rottnest Island Authority. Failure to return stickers to RIA upon request can result in the cancellation of your {{ approval.description }}. Once revoked, it cannot be reinstated.</p>
+{% endif %}
 {% endif %}
 {% if details %}<p>Details: {{ details }}</p>{% endif %}
 {% include "mooringlicensing/emails/signature-rottnest.html" %}

--- a/mooringlicensing/templates/mooringlicensing/emails_2/email_30_future.txt
+++ b/mooringlicensing/templates/mooringlicensing/emails_2/email_30_future.txt
@@ -2,6 +2,14 @@
 
 {% block content_body %}
 {% include "mooringlicensing/emails_2/salutation.txt" %}
+{% if approval.current_proposal.application_type.code == 'mla' %}
+Your {{ approval.description }} {{ approval.lodgement_number }} for mooring site {{ approval.child_obj.mooring.name }} will be surrendered as per {{ surrender_date }}.
+As per your licence conditions you must return all associated sticker(s) from your vessel(s)
+{% for sticker in stickers_to_be_returned %}
+{{ sticker.number }}{% if forloop.last %}{% else %},{% endif %}
+{% endfor %}
+to the Rottnest Island Authority. Failure to return current boating season stickers to RIA will affect applicable refunds. If you have already returned your sticker(s), your refund will be processed shortly.
+{% else %}
 Your {{ approval.description }} {{ approval.lodgement_number }} will be surrendered as per {{ surrender_date }}.
 {% if stickers_to_be_returned|length > 0 %}
 If you have not already done so, per your permit(s) conditions, you are required to return all associated vessel sticker(s)
@@ -9,6 +17,7 @@ If you have not already done so, per your permit(s) conditions, you are required
     {{ sticker.number }}{% if forloop.last %}{% else %},{% endif %}
     {% endfor %}
 to the Rottnest Island Authority. Failure to return stickers to RIA upon request can result in the cancellation of your {{ approval.description }}. Once revoked, it cannot be reinstated.
+{% endif %}
 {% endif %}
 {% if details %}Details: {{ details }}{% endif %}
 {% include "mooringlicensing/emails/signature-rottnest.txt" %}


### PR DESCRIPTION
Changed email template as specified in issue - using conditions within the template

Also change the future email version of the same template based on common elements.

Fixed a number of unintended surrender blocks for related AUPs on ML (similar to previous fixes for the same issue)