### PR TITLE
Amendment Request for Renewals fix

### DIFF
--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -2412,7 +2412,16 @@ class Proposal(RevisionedMixin):
                 logger.error(msg)
                 raise Exception(msg)
         elif self.proposal_type.code == settings.PROPOSAL_TYPE_RENEWAL:
-            if applied_date < self.approval.latest_applied_season.start_date:  # This should be same as self.approval.expiry_date
+
+            #check if this proposal has an associated amendment request, if it does treat as a reissue if outside original season
+            amendment_request_exists = AmendmentRequest.objects.filter(proposal=self).exists()
+
+            if (
+                applied_date < self.approval.latest_applied_season.start_date or 
+                    (self.approval.latest_applied_season.start_date <= applied_date <= self.approval.latest_applied_season.end_date and
+                        amendment_request_exists
+                    )
+                ):  # This should be same as self.approval.expiry_date
                 # This renewal is being applied before the latest season starts
                 # Therefore this application is renewal application reissued.
                 target_date = self.approval.latest_applied_season.start_date


### PR DESCRIPTION
Fixes error where amendment requests on renewal applications would use the wrong fee season if re-submitted in the next season

Fix works now by checking if an amendment request exists for the application and treating it as a reissue if it does 