### PR TITLE
ML Fixes

### DIFF
--- a/mooringlicensing/components/approvals/api.py
+++ b/mooringlicensing/components/approvals/api.py
@@ -43,7 +43,7 @@ from mooringlicensing.components.approvals.models import (
     Approval,
     DcvPermit, DcvOrganisation, DcvVessel, DcvAdmission, DcvAdmissionArrival, AdmissionType, AgeGroup,
     WaitingListAllocation, Sticker, MooringLicence,AuthorisedUserPermit, AnnualAdmissionPermit,
-    MooringOnApproval, VesselOwnershipOnApproval
+    MooringOnApproval, VesselOwnershipOnApproval, ApprovalUserAction
 )
 from mooringlicensing.components.approvals.utils import get_wla_allowed
 from mooringlicensing.components.main.process_document import (
@@ -710,6 +710,9 @@ class ApprovalViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
             serializer = StickerPostalAddressSaveSerializer(sticker,data=data)
             serializer.is_valid(raise_exception=True)
             serializer.save()
+
+            ApprovalUserAction.log_action(sticker.approval,ApprovalUserAction.ACTION_UPDATE_STICKER_ADDRESS.format(sticker.number),request.user)
+
         return Response()
 
     @detail_route(methods=['GET'], detail=True)
@@ -1785,6 +1788,9 @@ class StickerViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
         # Update Sticker
         sticker.record_returned()
         serializer = StickerSerializer(sticker)
+
+        ApprovalUserAction.log_action(sticker.approval,ApprovalUserAction.ACTION_STICKER_RETURNED.format(sticker.number),request.user)
+
         return Response({'sticker': serializer.data})
 
     @detail_route(methods=['POST',], detail=True)
@@ -1807,6 +1813,8 @@ class StickerViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
         # Update Sticker
         sticker.record_lost()
         serializer = StickerSerializer(sticker)
+
+        ApprovalUserAction.log_action(sticker.approval,ApprovalUserAction.ACTION_STICKER_LOST.format(sticker.number),request.user)
 
         return Response({'sticker': serializer.data})
 
@@ -1832,6 +1840,8 @@ class StickerViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
         serializer = StickerActionDetailSerializer(data=data)
         serializer.is_valid(raise_exception=True)
         details = serializer.save()
+
+        ApprovalUserAction.log_action(sticker.approval,ApprovalUserAction.ACTION_REQUEST_NEW_STICKER.format(sticker.number),request.user)
 
         return Response({'sticker_action_detail_ids': [details.id,]})
 

--- a/mooringlicensing/components/approvals/models.py
+++ b/mooringlicensing/components/approvals/models.py
@@ -2854,6 +2854,11 @@ class ApprovalUserAction(UserAction):
     ACTION_REISSUE_APPROVAL_ML = "Reissued due to change in Mooring Site Licence {}"
     ACTION_RENEWAL_NOTICE_SENT_FOR_APPROVAL = "Renewal notice sent for approval: {}"
 
+    ACTION_STICKER_LOST = "Sticker recorded lost {}"
+    ACTION_REQUEST_NEW_STICKER = "Request new sticker {}"
+    ACTION_UPDATE_STICKER_ADDRESS = "Update sticker address {}"
+    ACTION_STICKER_RETURNED = "Sticker recorded returned {}"
+
     class Meta:
         app_label = 'mooringlicensing'
         ordering = ('-when',)

--- a/mooringlicensing/components/payments_ml/views.py
+++ b/mooringlicensing/components/payments_ml/views.py
@@ -272,8 +272,8 @@ class StickerReplacementFeeView(TemplateView):
                         'price_excl_tax': total_amount_excl_tax,
                         'quantity': 1,
                     }
-                    if not applicant:
-                        applicant = sticker_action_detail.approval.applicant_obj
+                    if not applicant and sticker_action_detail and sticker_action_detail.sticker and sticker_action_detail.sticker.approval:
+                        applicant = sticker_action_detail.sticker.approval.applicant_obj
                     lines.append(line)
 
 

--- a/mooringlicensing/components/proposals/models.py
+++ b/mooringlicensing/components/proposals/models.py
@@ -1835,8 +1835,10 @@ class Proposal(RevisionedMixin):
                 fee_item_application_fees = FeeItemApplicationFee.objects.filter(application_fee=application_fee)
                 fee_item_application_fees.update(vessel_details=self.vessel_details)
 
+                # TODO only reset this flag if it is a renewal
                 # always reset this flag
                 approval.renewal_sent = False
+                
                 if type(self.child_obj) == AnnualAdmissionApplication:
                     approval.export_to_mooring_booking = True
                 approval.save()
@@ -3814,8 +3816,10 @@ class AuthorisedUserApplication(Proposal):
                     compliance.save()
                 self.generate_compliances(approval, request)
 
-            # always reset this flag
-            approval.renewal_sent = False
+            # only reset this flag if it is a renewal
+            if self.proposal_type.code == PROPOSAL_TYPE_RENEWAL:
+                approval.renewal_sent = False
+                
             approval.export_to_mooring_booking = True
             approval.save()
 
@@ -4500,8 +4504,10 @@ class MooringLicenceApplication(Proposal):
                     request
                 )
                 
-            # always reset this flag
-            approval.renewal_sent = False
+            # only reset this flag if it is a renewal
+            if self.proposal_type.code == PROPOSAL_TYPE_RENEWAL:
+                approval.renewal_sent = False
+
             approval.export_to_mooring_booking = True
             approval.save()
 


### PR DESCRIPTION
- renewal sent flag now only reset after renewal approval
- various sticker actions now logged on respective approval
- only relevant rego nos shown in approval email reports